### PR TITLE
Memory leak with CORK_HASH_TABLE_MAP_DELETE

### DIFF
--- a/src/libcork/ds/hash-table.c
+++ b/src/libcork/ds/hash-table.c
@@ -492,8 +492,12 @@ cork_hash_table_map(struct cork_hash_table *table,
             if (result == CORK_HASH_TABLE_MAP_ABORT) {
                 return;
             } else if (result == CORK_HASH_TABLE_MAP_DELETE) {
+                struct cork_hash_table_entry  *entry =
+                    cork_container_of
+                    (curr, struct cork_hash_table_entry, siblings);
                 DEBUG("      Delete requested");
                 cork_dllist_remove(curr);
+                free(entry);
                 table->entry_count--;
             }
 


### PR DESCRIPTION
If you use the `cork_hash_table_map` function to delete the entries in a hash table (by returning `CORK_HASH_TABLE_MAP_DELETE` as the result of the mapping function) then you get a memory leak.  The mapper removes the current element from its hash table bin, but doesn't `free` the entry instance.
