### PR TITLE
Libcork build generates compiler warning (unused function)

### DIFF
--- a/tests/test-mempool.c
+++ b/tests/test-mempool.c
@@ -143,7 +143,12 @@ test_suite()
 
     TCase  *tc_mempool = tcase_create("mempool");
     tcase_add_test(tc_mempool, test_mempool_01);
+#if NDEBUG
+    /* If we're not compiling assertions then this test won't abort */
+    tcase_add_test(tc_mempool, test_mempool_fail_01);
+#else
     tcase_add_test_raise_signal(tc_mempool, test_mempool_fail_01, SIGABRT);
+#endif
     tcase_add_test(tc_mempool, test_mempool_reuse_01);
     suite_add_tcase(s, tc_mempool);
 


### PR DESCRIPTION
While building libcork (`make`), the compiler generates a warning of an unused function. The basic conditions are: (1) Mac OS X w/ Xcode 4.3; (2) having removed libcork via `epkg -r libcork`; (3) stock cloned code from Github. This warning was generated in the version of libcork prior to thread-local storage (the warning was moved to another file but it was associated with the same `cork_error_destroy`/`cork_error__tls_destroy` function.

```
Scanning dependencies of target embedded_libcork
[  3%] Building C object src/CMakeFiles/embedded_libcork.dir/libcork/core/allocator.c.o
[  5%] Building C object src/CMakeFiles/embedded_libcork.dir/libcork/core/error.c.o
cc1: warnings being treated as errors
/Users/jzachary/redjack/libcork/src/libcork/core/error.c:46: warning: ‘cork_error__tls_destroy’ defined but not used
make[2]: *** [src/CMakeFiles/embedded_libcork.dir/libcork/core/error.c.o] Error 1
make[1]: *** [src/CMakeFiles/embedded_libcork.dir/all] Error 2
make: *** [all] Error 2
```

Asking the compiler to ignore this warning will result in a build but 18 out of 22 tests will fail with `make test`.
