### PR TITLE
Standard constructor for system errors

### DIFF
--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -361,12 +361,19 @@ applicable.  In almost all cases, you'll want to define a more specific
 error class and code instead.
 
 .. macro:: CORK_BUILTIN_ERROR
+           CORK_SYSTEM_ERROR
            CORK_UNKNOWN_ERROR
 
    The error class and codes used for the error conditions described in
    this section.
 
-.. function:: int cork_unknown_error_set(void)
+.. function:: void cork_system_error_set(void)
+
+   Fills in the current error condition with information from the C
+   library's ``errno`` variable.  The human-readable description of the
+   error will be obtained from the standard ``strerror`` function.
+
+.. function:: void cork_unknown_error_set(void)
 
    Fills in the current error condition to indicate that there was some
    unknown error.  The error description will include the name of the

--- a/docs/stream.rst
+++ b/docs/stream.rst
@@ -72,7 +72,7 @@ producer that reads data from a file::
       if (feof(fp)) {
           return cork_stream_consumer_eof(consumer);
       } else {
-          /* fill in an error condition */
+          cork_system_error_set();
           return -1;
       }
   }
@@ -147,7 +147,7 @@ consumer that writes data to a file::
       if (bytes_written == size) {
           return 0;
       } else {
-          /* fill in an error condition */
+          cork_system_error_set();
           return -1;
       }
   }
@@ -171,9 +171,7 @@ consumer that writes data to a file::
   struct cork_stream_consumer *
   file_consumer_new(FILE *fp)
   {
-      struct file_consumer  *self;
-      rp_check_new(struct file_consumer, self);
-
+      struct file_consumer  *self = cork_new(struct file_consumer);
       self->parent.data = file_consumer_data;
       self->parent.eof = file_consumer_eof;
       self->parent.free = file_consumer_free;

--- a/include/libcork/core/error.h
+++ b/include/libcork/core/error.h
@@ -53,9 +53,14 @@ cork_error_clear(void);
 #define CORK_BUILTIN_ERROR  0xd178dde5
 
 enum cork_builtin_error {
+    /* An error reported by the C library's errno mechanism */
+    CORK_SYSTEM_ERROR,
     /* An unknown error */
     CORK_UNKNOWN_ERROR
 };
+
+void
+cork_system_error_set(void);
 
 void
 cork_unknown_error_set_(const char *location);

--- a/src/libcork/core/error.c
+++ b/src/libcork/core/error.c
@@ -9,6 +9,7 @@
  */
 
 #include <assert.h>
+#include <errno.h>
 #include <stdarg.h>
 #include <string.h>
 
@@ -97,6 +98,14 @@ cork_error_clear(void)
     struct cork_error  *error = cork_error_get();
     error->error_class = CORK_ERROR_NONE;
     error->error_code = 0;
+}
+
+void
+cork_system_error_set(void)
+{
+    cork_error_set
+        (CORK_BUILTIN_ERROR, CORK_SYSTEM_ERROR,
+         "%s", strerror(errno));
 }
 
 void

--- a/tests/helpers.h
+++ b/tests/helpers.h
@@ -45,6 +45,7 @@
         } else { \
             print_expected_failure(); \
         } \
+        cork_error_clear(); \
     } while (0)
 
 #define fail_unless_equal(what, format, expected, actual) \

--- a/tests/test-core.c
+++ b/tests/test-core.c
@@ -8,9 +8,11 @@
  * ----------------------------------------------------------------------
  */
 
+#include <errno.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 
 #include <check.h>
 
@@ -163,6 +165,28 @@ START_TEST(test_endianness)
                 1, 2, 3, 4, 5, 6, 7, 8);
 
 #undef TEST_ENDIAN
+}
+END_TEST
+
+
+/*-----------------------------------------------------------------------
+ * Built-in errors
+ */
+
+START_TEST(test_system_error)
+{
+    DESCRIBE_TEST;
+
+    /* Artificially flag a system error and make sure we can detect it */
+    errno = ENOMEM;
+    cork_error_clear();
+    cork_system_error_set();
+    fail_unless(cork_error_get_class() == CORK_BUILTIN_ERROR,
+                "Expected a built-in error");
+    fail_unless(cork_error_get_code() == CORK_SYSTEM_ERROR,
+                "Expected a system error");
+    printf("Got error: %s\n", cork_error_message());
+    cork_error_clear();
 }
 END_TEST
 
@@ -491,6 +515,10 @@ test_suite()
     TCase  *tc_endianness = tcase_create("endianness");
     tcase_add_test(tc_endianness, test_endianness);
     suite_add_tcase(s, tc_endianness);
+
+    TCase  *tc_errors = tcase_create("errors");
+    tcase_add_test(tc_errors, test_system_error);
+    suite_add_tcase(s, tc_errors);
 
     TCase  *tc_hash = tcase_create("hash");
     tcase_add_test(tc_hash, test_hash);


### PR DESCRIPTION
It would be nice to have a standardized way to promote a C library error (given by the `errno` global variable) into a libcork error.
