### PR TITLE
Additional timestamp support

### DIFF
--- a/docs/timestamps.rst
+++ b/docs/timestamps.rst
@@ -27,14 +27,17 @@ High-precision timestamps
 
 
 .. function:: void cork_timestamp_init_sec(cork_timestamp \*ts, uint32_t sec)
+              void cork_timestamp_init_gsec(cork_timestamp \*ts, uint32_t sec, uint32_t gsec)
               void cork_timestamp_init_msec(cork_timestamp \*ts, uint32_t sec, uint32_t msec)
               void cork_timestamp_init_usec(cork_timestamp \*ts, uint32_t sec, uint32_t usec)
+              void cork_timestamp_init_nsec(cork_timestamp \*ts, uint32_t sec, uint32_t nsec)
 
    Initializes a timestamp from a separate seconds part and fractional
    part.  For the ``_sec`` variant, the fractional part will be set to
-   ``0``.  For the ``_msec`` and ``_usec`` variants, the fractional part
-   will be translated into gammaseconds from milliseconds or
-   microseconds, respectively.
+   ``0``.  For the ``_gsec`` variant, you provide the fractional part in
+   gammaseconds.  For the ``_msec``, ``_usec``, and ``_nsec`` variants, the
+   fractional part will be translated into gammaseconds from milliseconds,
+   microseconds, or nanoseconds, respectively.
 
 
 .. function:: void cork_timestamp_init_now(cork_timestamp \*ts)
@@ -47,10 +50,17 @@ High-precision timestamps
 
 
 .. function:: uint32_t cork_timestamp_sec(const cork_timestamp ts)
-              uint32_t cork_timestamp_gsec(const cork_timestamp ts)
 
-   Returns the seconds or fractional portion, respectively, of a
-   timestamp.  The fractional portion is represented in gammaseconds.
+   Returns the seconds portion of a timestamp.
+
+.. function:: uint32_t cork_timestamp_gsec(const cork_timestamp ts)
+              uint32_t cork_timestamp_msec(const cork_timestamp ts)
+              uint32_t cork_timestamp_usec(const cork_timestamp ts)
+              uint32_t cork_timestamp_nsec(const cork_timestamp ts)
+
+   Returns the fractional portion of a timestamp.  The variants return the
+   fractional portion in, respectively, gammaseconds, milliseconds,
+   microseconds, or nanoseconds.
 
 
 .. function:: bool cork_timestamp_format_utc(const cork_timestamp ts, const char \*format, char \*buf, size_t size)

--- a/include/libcork/core/timestamp.h
+++ b/include/libcork/core/timestamp.h
@@ -24,6 +24,12 @@ typedef uint64_t  cork_timestamp;
         *(ts) = (((uint64_t) (sec)) << 32); \
     } while (0)
 
+#define cork_timestamp_init_gsec(ts, sec, gsec) \
+    do { \
+        *(ts) = (((uint64_t) (sec)) << 32) | \
+                (((uint64_t) (gsec)) & 0xffffffff); \
+    } while (0)
+
 #define cork_timestamp_init_msec(ts, sec, msec) \
     do { \
         *(ts) = (((uint64_t) (sec)) << 32) | \
@@ -36,13 +42,24 @@ typedef uint64_t  cork_timestamp;
                 ((((uint64_t) (usec)) << 32) / 1000000); \
     } while (0)
 
+#define cork_timestamp_init_nsec(ts, sec, nsec) \
+    do { \
+        *(ts) = (((uint64_t) (sec)) << 32) | \
+                ((((uint64_t) (nsec)) << 32) / 1000000000); \
+    } while (0)
+
 
 void
 cork_timestamp_init_now(cork_timestamp *ts);
 
 
 #define cork_timestamp_sec(ts)  ((uint32_t) ((ts) >> 32))
-#define cork_timestamp_gsec(ts)  ((uint32_t) ((ts) & 0xFFFFFFFF))
+#define cork_timestamp_gsec(ts)  ((uint32_t) ((ts) & 0xffffffff))
+#define cork_timestamp_gsec_to_units(ts, denom) \
+    (((uint64_t) (ts) & 0xffffffff) * (denom) >> 32)
+#define cork_timestamp_msec(ts)  cork_timestamp_gsec_to_units(ts, 1000)
+#define cork_timestamp_usec(ts)  cork_timestamp_gsec_to_units(ts, 1000000)
+#define cork_timestamp_nsec(ts)  cork_timestamp_gsec_to_units(ts, 1000000000)
 
 
 bool

--- a/tests/test-core.c
+++ b/tests/test-core.c
@@ -478,6 +478,7 @@ END_TEST
 
 START_TEST(test_timestamp)
 {
+    DESCRIBE_TEST;
     static char  buf[4096];
     static size_t  size = sizeof(buf);
 
@@ -509,25 +510,54 @@ START_TEST(test_timestamp)
     cork_timestamp_init_sec(&ts, TEST_TIME_1);
     test(sec, TEST_TIME_1);
     test(gsec, 0);
+    test(msec, 0);
+    test(usec, 0);
+    test(nsec, 0);
     test_format(FORMATTED_TIME_1);
 
     cork_timestamp_init_sec(&ts, TEST_TIME_2);
     test(sec, TEST_TIME_2);
     test(gsec, 0);
+    test(msec, 0);
+    test(usec, 0);
+    test(nsec, 0);
     test_format(FORMATTED_TIME_2);
 
     cork_timestamp_init_sec(&ts, TEST_TIME_3);
     test(sec, TEST_TIME_3);
     test(gsec, 0);
+    test(msec, 0);
+    test(usec, 0);
+    test(nsec, 0);
     test_format(FORMATTED_TIME_3);
+
+    cork_timestamp_init_gsec(&ts, TEST_TIME_1, 1 << 30);
+    test(sec, TEST_TIME_1);
+    test(gsec, 1 << 30);
+    test(msec, 250);
+    test(usec, 250000);
+    test(nsec, 250000000);
 
     cork_timestamp_init_msec(&ts, TEST_TIME_1, 500);
     test(sec, TEST_TIME_1);
     test(gsec, 1 << 31);
+    test(msec, 500);
+    test(usec, 500000);
+    test(nsec, 500000000);
 
     cork_timestamp_init_usec(&ts, TEST_TIME_1, 500000);
     test(sec, TEST_TIME_1);
     test(gsec, 1 << 31);
+    test(msec, 500);
+    test(usec, 500000);
+    test(nsec, 500000000);
+
+    cork_timestamp_init_nsec(&ts, TEST_TIME_1, 500000000);
+    test(sec, TEST_TIME_1);
+    test(gsec, 1 << 31);
+    test(msec, 500);
+    test(usec, 500000);
+    test(nsec, 500000000);
 }
 END_TEST
 


### PR DESCRIPTION
At times, there may be reasons to serialize a cork timestamp as a pair of ints, rather than as a long.  This will be true when the fractional value (gsec) is zero, however, even in the worst case, the space required by the serialized pair of ints is 10 bytes , the same as for the 64bit representation.  The payoff comes when the gsec portion is zero as it can be transmitted as a single byte.

In order to take advantage of this encoding, we need an additional cork timestamp init constructor

``` c
void cork_timestamp_init_gsec(cork_timestamp *ts, uint32_t sec, uint32_t gsec);
```

In addition, it would be useful to be able to initialize from distinct second and nanosecond values as in

``` C
void cork_timestamp_init_nsec(cork_timestamp *ts, uint32_t sec, uint32_t nsec);
```

A third extension would be the ability to format a timestamp for any arbitrary time zone.  I'm not sure what the appropriate representation for a time zone is, but the interface should be something like

``` C
bool cork_timestamp_format_tz(const cork_timestamp ts, const tz_type tz, 
                              const char *format, char *buf, size_t size);
```
