### PR TITLE
cork_ipv4_init does not like leading 0s on Linux

### DIFF
--- a/include/libcork/core/net-addresses.h
+++ b/include/libcork/core/net-addresses.h
@@ -38,6 +38,7 @@ enum cork_net_address_error {
 struct cork_ipv4 {
     union {
         uint8_t  u8[4];
+        uint16_t  u16[2];
         uint32_t  u32;
     } _;
 };
@@ -45,6 +46,8 @@ struct cork_ipv4 {
 struct cork_ipv6 {
     union {
         uint8_t  u8[16];
+        uint16_t  u16[8];
+        uint32_t  u32[4];
         uint64_t  u64[2];
     } _;
 };

--- a/src/libcork/core/ip-address.c
+++ b/src/libcork/core/ip-address.c
@@ -8,7 +8,6 @@
  * ----------------------------------------------------------------------
  */
 
-#include <arpa/inet.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -17,6 +16,20 @@
 #include "libcork/core/net-addresses.h"
 #include "libcork/core/types.h"
 
+#ifndef CORK_IP_ADDRESS_DEBUG
+#define CORK_IP_ADDRESS_DEBUG 0
+#endif
+
+#if CORK_IP_ADDRESS_DEBUG
+#include <stdio.h>
+#define DEBUG(...) \
+    do { \
+        fprintf(stderr, __VA_ARGS__); \
+    } while (0)
+#else
+#define DEBUG(...) /* nothing */
+#endif
+
 
 /*-----------------------------------------------------------------------
  * IP addresses
@@ -24,24 +37,78 @@
 
 /*** IPv4 ***/
 
+static inline const char *
+cork_ipv4_parse(struct cork_ipv4 *addr, const char *str)
+{
+    const char  *ch;
+    bool  seen_digit_in_octet = false;
+    unsigned int  octets = 0;
+    unsigned int  digit = 0;
+    uint8_t  result[4];
+
+    for (ch = str; *ch != '\0'; ch++) {
+        DEBUG("%2u: %c\t", (unsigned int) (ch-str), *ch);
+        switch (*ch) {
+            case '0': case '1': case '2': case '3': case '4':
+            case '5': case '6': case '7': case '8': case '9':
+                seen_digit_in_octet = true;
+                digit *= 10;
+                digit += (*ch - '0');
+                DEBUG("digit = %u\n", digit);
+                if (CORK_UNLIKELY(digit > 255)) {
+                    DEBUG("\t");
+                    goto parse_error;
+                }
+                break;
+
+            case '.':
+                /* If this would be the fourth octet, it can't have a trailing
+                 * period. */
+                if (CORK_UNLIKELY(octets == 3)) {
+                    goto parse_error;
+                }
+                DEBUG("octet %u = %u\n", octets, digit);
+                result[octets] = digit;
+                digit = 0;
+                octets++;
+                seen_digit_in_octet = false;
+                break;
+
+            default:
+                /* Any other character is a parse error. */
+                goto parse_error;
+        }
+    }
+
+    /* If we have a valid octet at the end, and that would be the fourth octet,
+     * then we've got a valid final parse. */
+    DEBUG("%2u:\t", (unsigned int) (ch-str));
+    if (CORK_LIKELY(seen_digit_in_octet && octets == 3)) {
+#if CORK_IP_ADDRESS_DEBUG
+        char  parsed_ipv4[CORK_IPV4_STRING_LENGTH];
+#endif
+        DEBUG("octet %u = %u\n", octets, digit);
+        result[octets] = digit;
+        cork_ipv4_copy(addr, result);
+#if CORK_IP_ADDRESS_DEBUG
+        cork_ipv4_to_raw_string(addr, parsed_ipv4);
+        DEBUG("\tParsed address: %s\n", parsed_ipv4);
+#endif
+        return ch;
+    }
+
+parse_error:
+    DEBUG("parse error\n");
+    cork_error_set
+        (CORK_NET_ADDRESS_ERROR, CORK_NET_ADDRESS_PARSE_ERROR,
+         "Invalid IPv4 address: \"%s\"", str);
+    return NULL;
+}
+
 int
 cork_ipv4_init(struct cork_ipv4 *addr, const char *str)
 {
-    int  rc = inet_pton(AF_INET, str, addr);
-
-    if (rc == 1) {
-        /* successful parse */
-        return 0;
-    } else if (rc == 0) {
-        /* parse error */
-        cork_error_set
-            (CORK_NET_ADDRESS_ERROR, CORK_NET_ADDRESS_PARSE_ERROR,
-             "Invalid IPv4 address: \"%s\"", str);
-        return -1;
-    } else {
-        cork_unknown_error();
-        return -1;
-    }
+    return cork_ipv4_parse(addr, str) == NULL? -1: 0;
 }
 
 bool
@@ -80,21 +147,194 @@ cork_ipv4_is_valid_network(const struct cork_ipv4 *addr,
 int
 cork_ipv6_init(struct cork_ipv6 *addr, const char *str)
 {
-    int  rc = inet_pton(AF_INET6, str, addr);
+    const char  *ch;
 
-    if (rc == 1) {
-        /* successful parse */
-        return 0;
-    } else if (rc == 0) {
-        /* parse error */
-        cork_error_set
-            (CORK_NET_ADDRESS_ERROR, CORK_NET_ADDRESS_PARSE_ERROR,
-             "Invalid IPv6 address: \"%s\"", str);
-        return -1;
-    } else {
-        cork_unknown_error();
-        return -1;
+    uint16_t  digit = 0;
+    unsigned int  before_count = 0;
+    uint16_t  before_double_colon[8];
+    uint16_t  after_double_colon[8];
+    uint16_t  *dest = before_double_colon;
+
+    unsigned int  digits_seen = 0;
+    unsigned int  hextets_seen = 0;
+    bool  another_required = true;
+    bool  digit_allowed = true;
+    bool  colon_allowed = true;
+    bool  double_colon_allowed = true;
+    bool  just_saw_colon = false;
+
+    for (ch = str; *ch != '\0'; ch++) {
+        DEBUG("%2u: %c\t", (unsigned int) (ch-str), *ch);
+        switch (*ch) {
+#define process_digit(base) \
+                /* Make sure a digit is allowed here. */ \
+                if (CORK_UNLIKELY(!digit_allowed)) { \
+                    goto parse_error; \
+                } \
+                /* If we've already seen 4 digits, it's a parse error. */ \
+                if (CORK_UNLIKELY(digits_seen == 4)) { \
+                    goto parse_error; \
+                } \
+                \
+                digits_seen++; \
+                colon_allowed = true; \
+                just_saw_colon = false; \
+                digit <<= 4; \
+                digit |= (*ch - (base)); \
+                DEBUG("digit = %04x\n", digit);
+
+            case '0': case '1': case '2': case '3': case '4':
+            case '5': case '6': case '7': case '8': case '9':
+                process_digit('0');
+                break;
+
+            case 'a': case 'b': case 'c': case 'd': case 'e': case 'f':
+                process_digit('a'-10);
+                break;
+
+            case 'A': case 'B': case 'C': case 'D': case 'E': case 'F':
+                process_digit('A'-10);
+                break;
+
+#undef process_digit
+
+            case ':':
+                /* We can only see a colon immediately after a hextet or as part
+                 * of a double-colon. */
+                if (CORK_UNLIKELY(!colon_allowed)) {
+                    goto parse_error;
+                }
+
+                /* If this is a double-colon, start parsing hextets into our
+                 * second array. */
+                if (just_saw_colon) {
+                    DEBUG("double-colon\n");
+                    colon_allowed = false;
+                    digit_allowed = true;
+                    another_required = false;
+                    double_colon_allowed = false;
+                    before_count = hextets_seen;
+                    dest = after_double_colon;
+                    continue;
+                }
+
+                /* If this would end the eighth hextet (regardless of the
+                 * placement of a double-colon), then there can't be a trailing
+                 * colon. */
+                if (CORK_UNLIKELY(hextets_seen == 8)) {
+                    goto parse_error;
+                }
+
+                /* If this is the very beginning of the string, then we can only
+                 * have a double-colon, not a single colon. */
+                if (digits_seen == 0 && hextets_seen == 0) {
+                    DEBUG("initial colon\n");
+                    colon_allowed = true;
+                    digit_allowed = false;
+                    just_saw_colon = true;
+                    another_required = true;
+                    continue;
+                }
+
+                /* Otherwise this ends the current hextet. */
+                DEBUG("hextet %u = %04x\n", hextets_seen, digit);
+                *(dest++) = CORK_UINT16_HOST_TO_BIG(digit);
+                digit = 0;
+                hextets_seen++;
+                digits_seen = 0;
+                colon_allowed = double_colon_allowed;
+                just_saw_colon = true;
+                another_required = true;
+                break;
+
+            case '.':
+            {
+                /* If we see a period, then we must be in the middle of an IPv4
+                 * address at the end of the IPv6 address. */
+                struct cork_ipv4  *ipv4 = (struct cork_ipv4 *) dest;
+                DEBUG("Detected IPv4 address %s\n", ch-digits_seen);
+
+                /* Ensure that we have space for the two hextets that the IPv4
+                 * address will take up. */
+                if (CORK_UNLIKELY(hextets_seen >= 7)) {
+                    goto parse_error;
+                }
+
+                /* Parse the IPv4 address directly into our current hextet
+                 * buffer. */
+                ch = cork_ipv4_parse(ipv4, ch - digits_seen);
+                if (CORK_LIKELY(ch != NULL)) {
+                    hextets_seen += 2;
+                    digits_seen = 0;
+                    another_required = false;
+
+                    /* ch now points at the NUL terminator, but we're about to
+                     * increment ch. */
+                    ch--;
+                    break;
+                }
+
+                /* The IPv4 parse failed, so we have an IPv6 parse error. */
+                goto parse_error;
+            }
+
+            default:
+                /* Any other character is a parse error. */
+                goto parse_error;
+        }
     }
+
+    /* If we have a valid hextet at the end, and we've either seen a
+     * double-colon, or we have eight hextets in total, then we've got a valid
+     * final parse. */
+    DEBUG("%2u:\t", (unsigned int) (ch-str));
+    if (CORK_LIKELY(digits_seen > 0)) {
+        DEBUG("hextet %u = %04x\n\t", hextets_seen, digit);
+        *(dest++) = CORK_UINT16_HOST_TO_BIG(digit);
+        hextets_seen++;
+    } else if (CORK_UNLIKELY(another_required)) {
+        goto parse_error;
+    }
+
+    if (!double_colon_allowed) {
+        /* We've seen a double-colon, so use 0000 for any hextets that weren't
+         * present. */
+#if CORK_IP_ADDRESS_DEBUG
+        char  parsed_result[CORK_IPV6_STRING_LENGTH];
+#endif
+        unsigned int  after_count = hextets_seen - before_count;
+        DEBUG("Saw double-colon; %u hextets before, %u after\n",
+              before_count, after_count);
+        memset(addr, 0, sizeof(struct cork_ipv6));
+        memcpy(addr, before_double_colon,
+               sizeof(uint16_t) * before_count);
+        memcpy(&addr->_.u16[8-after_count], after_double_colon,
+               sizeof(uint16_t) * after_count);
+#if CORK_IP_ADDRESS_DEBUG
+        cork_ipv6_to_raw_string(addr, parsed_result);
+        DEBUG("\tParsed address: %s\n", parsed_result);
+#endif
+        return 0;
+    } else if (hextets_seen == 8) {
+        /* No double-colon, so we must have exactly eight hextets. */
+#if CORK_IP_ADDRESS_DEBUG
+        char  parsed_result[CORK_IPV6_STRING_LENGTH];
+#endif
+        DEBUG("No double-colon\n");
+        cork_ipv6_copy(addr, before_double_colon);
+#if CORK_IP_ADDRESS_DEBUG
+        cork_ipv6_to_raw_string(addr, parsed_result);
+        DEBUG("\tParsed address: %s\n", parsed_result);
+#endif
+        return 0;
+    }
+
+parse_error:
+    DEBUG("parse error\n");
+    cork_error_set
+        (CORK_NET_ADDRESS_ERROR, CORK_NET_ADDRESS_PARSE_ERROR,
+         "Invalid IPv6 address: \"%s\"", str);
+    return -1;
 }
 
 bool
@@ -237,31 +477,20 @@ cork_ip_init(struct cork_ip *addr, const char *str)
     int  rc;
 
     /* Try IPv4 first */
-
-    rc = inet_pton(AF_INET, str, &addr->ip.v4);
-
-    if (rc == 1) {
+    rc = cork_ipv4_init(&addr->ip.v4, str);
+    if (rc == 0) {
         /* successful parse */
         addr->version = 4;
         return 0;
-    } else if (rc != 0) {
-        /* non-parse error */
-        cork_unknown_error();
-        return -1;
     }
 
     /* Then try IPv6 */
-
-    rc = inet_pton(AF_INET6, str, &addr->ip.v6);
-
-    if (rc == 1) {
+    cork_error_clear();
+    rc = cork_ipv6_init(&addr->ip.v6, str);
+    if (rc == 0) {
         /* successful parse */
         addr->version = 6;
         return 0;
-    } else if (rc != 0) {
-        /* non-parse error */
-        cork_unknown_error();
-        return -1;
     }
 
     /* Parse error for both address types */

--- a/tests/test-core.c
+++ b/tests/test-core.c
@@ -242,43 +242,94 @@ END_TEST
  * IP addresses
  */
 
+#define IPV4_TESTS(good, bad) \
+    good("192.168.1.100", "192.168.1.100"); \
+    good("01.002.0003.00000004", "1.2.3.4"); \
+    good("010.0020.00034.00000089", "10.20.34.89"); \
+    good("0100.000200.00.000", "100.200.0.0"); \
+    bad("", -1); \
+    bad(".", -1); \
+    bad("192.168.0.", -1); \
+    bad("192.168.0.1.", -1); \
+    bad("192..168.0.1", -1); \
+    bad("192.168.0.1.2", -1); \
+    bad(".168.0.1.2", -1); \
+    bad("256.0.0.0", -1); \
+    bad("00256.0.0.0", -1); \
+    bad("392.0.0.0", -1); \
+    bad("1920.0.0.0", -1); \
+    bad("stuv", -1); \
+
+#define IPV6_TESTS(good, bad) \
+    good("::", "::"); \
+    good("0:0:0:0:0:0:0:0", "::"); \
+    good("0000:0000:0000:0000:0000:0000:0000:0000", "::"); \
+    good("fe80::", "fe80::"); \
+    good("fe80:0:0:0:0:0:0:0", "fe80::"); \
+    good("fe80:0000:0000:0000:0000:0000:0000:0000", "fe80::"); \
+    good("::1", "::1"); \
+    good("0:0:0:0:0:0:0:1", "::1"); \
+    good("0000:0000:0000:0000:0000:0000:0000:0001", "::1"); \
+    good("fe80::1", "fe80::1"); \
+    good("fe80:0:0:0:0:0:0:1", "fe80::1"); \
+    good("fe80:0000:0000:0000:0000:0000:0000:0001", "fe80::1"); \
+    good("0:1:2:3:4:5:6:7", "0:1:2:3:4:5:6:7"); \
+    good("1230:4567:89ab:cdef:1230:4567:89ab:cdef", \
+         "1230:4567:89ab:cdef:1230:4567:89ab:cdef"); \
+    good("::ffff:192.168.1.100", "::ffff:192.168.1.100"); \
+    bad("", -1); \
+    bad(":", -1); \
+    bad("fe80:", -1); \
+    bad("fe80::1::2", -1); \
+    bad("1:2:3:4:5:6:7", -1); \
+    bad("1:2:3:4:5:6:7:8:9", -1); \
+    bad("::1:", -1); \
+    bad("fe800::", -1); \
+    bad("stuv", -1); \
+    /* RFC 5952 recommendations */ \
+    good("2001:0db8::0001", "2001:db8::1"); \
+    good("2001:db8:0:0:0:0:2:1", "2001:db8::2:1"); \
+    good("2001:db8:0:1:1:1:1:1", "2001:db8:0:1:1:1:1:1"); \
+    good("2001:0:0:1:0:0:0:1", "2001:0:0:1::1"); \
+    good("2001:db8:0:0:1:0:0:1", "2001:db8::1:0:0:1"); \
+    good("0:1:A:B:C:D:E:F", "0:1:a:b:c:d:e:f"); \
+
 START_TEST(test_ipv4_address)
 {
     DESCRIBE_TEST;
 
-#define ROUND_TRIP(str) \
+#define GOOD(str, normalized) \
     { \
         struct cork_ipv4  addr; \
+        fprintf(stderr, "Trying \"%s\", expecting \"%s\"\n", str, normalized); \
         fail_if_error(cork_ipv4_init(&addr, str)); \
         char  actual[CORK_IPV4_STRING_LENGTH]; \
         cork_ipv4_to_raw_string(&addr, actual); \
-        fail_unless(strcmp(actual, str) == 0, \
+        fail_unless(strcmp(actual, normalized) == 0, \
                     "Unexpected string representation: " \
-                    "got %s, expected %s", \
-                    actual, str); \
+                    "got \"%s\", expected \"%s\"", \
+                    actual, normalized); \
         \
         struct cork_ipv4  addr2; \
-        cork_ipv4_init(&addr2, str); \
+        cork_ipv4_init(&addr2, normalized); \
         fail_unless(cork_ipv4_equal(&addr, &addr2), \
-                    "IPv4 cork_eq_t instances should be equal"); \
+                    "IPv4 instances should be equal"); \
     }
 
-#define BAD(str) \
+#define BAD(str, unused) \
     { \
         struct cork_ipv4  addr; \
+        fprintf(stderr, "Trying \"%s\", expecting parse error\n", str); \
         fail_unless_error \
             (cork_ipv4_init(&addr, str), \
-             "Shouldn't be able to initialize IPv4 address from %s", \
+             "Shouldn't be able to initialize IPv4 address from \"%s\"", \
              str); \
     }
 
-    ROUND_TRIP("192.168.1.100");
-    BAD("192.168.0.");
-    BAD("fe80::1");
-    BAD("::ffff:192.168.1.100");
-    BAD("abcd");
+    IPV4_TESTS(GOOD, BAD);
+    IPV6_TESTS(BAD, BAD);
 
-#undef ROUND_TRIP
+#undef GOOD
 #undef BAD
 
     struct cork_ipv4  addr4;
@@ -286,6 +337,7 @@ START_TEST(test_ipv4_address)
     unsigned int  ipv4_cidr_bad_value = 24;
     unsigned int  ipv4_cidr_bad_range = 33;
 
+    fprintf(stderr, "Testing network prefixes\n");
     cork_ipv4_init(&addr4, "1.2.3.4");
     fail_unless(cork_ipv4_is_valid_network(&addr4, ipv4_cidr_good),
                 "Bad CIDR block for 1.2.3.4 and %u",
@@ -304,40 +356,38 @@ START_TEST(test_ipv6_address)
 {
     DESCRIBE_TEST;
 
-#define ROUND_TRIP(str) \
+#define GOOD(str, normalized) \
     { \
         struct cork_ipv6  addr; \
+        fprintf(stderr, "Trying \"%s\", expecting \"%s\"\n", str, normalized); \
         fail_if_error(cork_ipv6_init(&addr, str)); \
         char  actual[CORK_IPV6_STRING_LENGTH]; \
         cork_ipv6_to_raw_string(&addr, actual); \
-        fail_unless(strcmp(actual, str) == 0, \
+        fail_unless(strcmp(actual, normalized) == 0, \
                     "Unexpected string representation: " \
-                    "got %s, expected %s", \
-                    actual, str); \
+                    "got \"%s\", expected \"%s\"", \
+                    actual, normalized); \
         \
         struct cork_ipv6  addr2; \
-        cork_ipv6_init(&addr2, str); \
+        cork_ipv6_init(&addr2, normalized); \
         fail_unless(cork_ipv6_equal(&addr, &addr2), \
-                    "IPv6 cork_eq_t instances should be equal"); \
+                    "IPv6 instances should be equal"); \
     }
 
-#define BAD(str) \
+#define BAD(str, unused) \
     { \
         struct cork_ipv6  addr; \
+        fprintf(stderr, "Trying \"%s\", expecting parse error\n", str); \
         fail_unless_error \
             (cork_ipv6_init(&addr, str), \
-             "Shouldn't be able to initialize IPv6 address from %s", \
+             "Shouldn't be able to initialize IPv6 address from \"%s\"", \
              str); \
     }
 
-    ROUND_TRIP("fe80::1");
-    ROUND_TRIP("::ffff:192.168.1.100");
-    BAD("fe80:");
-    BAD("fe80::1::2");
-    BAD("192.168.1.100");
-    BAD("abcd");
+    IPV6_TESTS(GOOD, BAD);
+    IPV4_TESTS(BAD, BAD);
 
-#undef ROUND_TRIP
+#undef GOOD
 #undef BAD
 
     struct cork_ipv6  addr6;
@@ -345,6 +395,7 @@ START_TEST(test_ipv6_address)
     unsigned int  ipv6_cidr_bad_value = 64;
     unsigned int  ipv6_cidr_bad_range = 129;
 
+    fprintf(stderr, "Testing network prefixes\n");
     cork_ipv6_init(&addr6, "fe80::200:f8ff:fe21:6000");
     fail_unless(cork_ipv6_is_valid_network(&addr6, ipv6_cidr_good),
                 "Bad CIDR block %u",
@@ -364,46 +415,44 @@ START_TEST(test_ip_address)
     DESCRIBE_TEST;
     struct cork_ip  addr;
 
-#define ROUND_TRIP(str) \
+#define GOOD(str, normalized) \
     { \
         struct cork_ip  addr; \
+        fprintf(stderr, "Trying \"%s\", expecting \"%s\"\n", str, normalized); \
         fail_if_error(cork_ip_init(&addr, str)); \
         char  actual[CORK_IP_STRING_LENGTH]; \
         cork_ip_to_raw_string(&addr, actual); \
-        fail_unless(strcmp(actual, str) == 0, \
+        fail_unless(strcmp(actual, normalized) == 0, \
                     "Unexpected string representation: " \
-                    "got %s, expected %s", \
-                    actual, str); \
+                    "got \"%s\", expected \"%s\"", \
+                    actual, normalized); \
         \
         struct cork_ip  addr2; \
-        cork_ip_init(&addr2, str); \
+        cork_ip_init(&addr2, normalized); \
         fail_unless(cork_ip_equal(&addr, &addr2), \
-                    "IP cork_eq_t instances should be equal"); \
+                    "IP instances should be equal"); \
     }
 
-#define BAD(str) \
+#define BAD(str, unused) \
     { \
         struct cork_ip  addr; \
+        fprintf(stderr, "Trying \"%s\", expecting parse error\n", str); \
         fail_unless_error \
             (cork_ip_init(&addr, str), \
-             "Shouldn't be able to initialize IP address from %s", \
+             "Shouldn't be able to initialize IP address from \"%s\"", \
              str); \
     }
 
-    ROUND_TRIP("192.168.1.100");
-    ROUND_TRIP("fe80::1");
-    ROUND_TRIP("::ffff:192.168.1.100");
-    BAD("192.168.0.");
-    BAD("fe80:");
-    BAD("fe80::1::2");
-    BAD("abcd");
+    IPV4_TESTS(GOOD, BAD);
+    IPV6_TESTS(GOOD, BAD);
 
-#undef ROUND_TRIP
+#undef GOOD
 #undef BAD
 
     struct cork_ipv4  addr4;
     struct cork_ipv6  addr6;
 
+    fprintf(stderr, "Testing IP address versions\n");
     cork_ip_init(&addr, "192.168.1.1");
     cork_ipv4_init(&addr4, "192.168.1.1");
     fail_unless(addr.version == 4,


### PR DESCRIPTION
The `cork_ipv4_init` function gives inconsistent results on Linux and Mac when you parse `192.168.001.002`.  On Mac, this parses fine (as 192.168.1.2), but on Linux, you get a parse error.
