### PR TITLE
Macro versions of IP address functions

### DIFF
--- a/include/libcork/core/net-addresses.h
+++ b/include/libcork/core/net-addresses.h
@@ -74,11 +74,14 @@ struct cork_ip {
 #define cork_ipv4_copy(addr, src) \
     (memcpy((addr), (src), sizeof(struct cork_ipv4)))
 
+#define cork_ipv4_equal(a1, a2) \
+    ((a1)->_.u32 == (a2)->_.u32)
+
 int
 cork_ipv4_init(struct cork_ipv4 *addr, const char *str);
 
 bool
-cork_ipv4_equal(const struct cork_ipv4 *addr1, const struct cork_ipv4 *addr2);
+cork_ipv4_equal_(const struct cork_ipv4 *addr1, const struct cork_ipv4 *addr2);
 
 void
 cork_ipv4_to_raw_string(const struct cork_ipv4 *addr, char *dest);
@@ -94,11 +97,15 @@ cork_ipv4_is_valid_network(const struct cork_ipv4 *addr,
 #define cork_ipv6_copy(addr, src) \
     (memcpy((addr), (src), sizeof(struct cork_ipv6)))
 
+#define cork_ipv6_equal(a1, a2) \
+    ((a1)->_.u64[0] == (a2)->_.u64[0] && \
+     (a1)->_.u64[1] == (a2)->_.u64[1])
+
 int
 cork_ipv6_init(struct cork_ipv6 *addr, const char *str);
 
 bool
-cork_ipv6_equal(const struct cork_ipv6 *addr1, const struct cork_ipv6 *addr2);
+cork_ipv6_equal_(const struct cork_ipv6 *addr1, const struct cork_ipv6 *addr2);
 
 void
 cork_ipv6_to_raw_string(const struct cork_ipv6 *addr, char *dest);
@@ -110,19 +117,38 @@ cork_ipv6_is_valid_network(const struct cork_ipv6 *addr,
 
 /*** Generic IP ***/
 
+#define cork_ip_equal(a1, a2) \
+    ((a1)->version == 4? \
+     ((a2)->version == 4 && cork_ipv4_equal(&(a1)->ip.v4, &(a2)->ip.v4)): \
+     ((a2)->version == 6 && cork_ipv6_equal(&(a1)->ip.v6, &(a2)->ip.v6)))
+
+/* src must be well-formed: 4 bytes, big-endian */
+#define cork_ip_from_ipv4(addr, src) \
+    do { \
+        (addr)->version = 4; \
+        cork_ipv4_copy(&(addr)->ip.v4, (src)); \
+    } while (0)
+
+/* src must be well-formed: 16 bytes, big-endian */
+#define cork_ip_from_ipv6(addr, src) \
+    do { \
+        (addr)->version = 6; \
+        cork_ipv6_copy(&(addr)->ip.v6, (src)); \
+    } while (0)
+
 /* src must be well-formed: 4 bytes, big-endian */
 void
-cork_ip_from_ipv4(struct cork_ip *addr, const void *src);
+cork_ip_from_ipv4_(struct cork_ip *addr, const void *src);
 
 /* src must be well-formed: 16 bytes, big-endian */
 void
-cork_ip_from_ipv6(struct cork_ip *addr, const void *src);
+cork_ip_from_ipv6_(struct cork_ip *addr, const void *src);
 
 int
 cork_ip_init(struct cork_ip *addr, const char *str);
 
 bool
-cork_ip_equal(const struct cork_ip *addr1, const struct cork_ip *addr2);
+cork_ip_equal_(const struct cork_ip *addr1, const struct cork_ip *addr2);
 
 void
 cork_ip_to_raw_string(const struct cork_ip *addr, char *dest);

--- a/src/libcork/core/ip-address.c
+++ b/src/libcork/core/ip-address.c
@@ -112,9 +112,9 @@ cork_ipv4_init(struct cork_ipv4 *addr, const char *str)
 }
 
 bool
-cork_ipv4_equal(const struct cork_ipv4 *addr1, const struct cork_ipv4 *addr2)
+cork_ipv4_equal_(const struct cork_ipv4 *addr1, const struct cork_ipv4 *addr2)
 {
-    return (memcmp(addr1, addr2, sizeof(struct cork_ipv4)) == 0);
+    return cork_ipv4_equal(addr1, addr2);
 }
 
 void
@@ -338,9 +338,9 @@ parse_error:
 }
 
 bool
-cork_ipv6_equal(const struct cork_ipv6 *addr1, const struct cork_ipv6 *addr2)
+cork_ipv6_equal_(const struct cork_ipv6 *addr1, const struct cork_ipv6 *addr2)
 {
-    return (memcmp(addr1, addr2, sizeof(struct cork_ipv6)) == 0);
+    return cork_ipv6_equal(addr1, addr2);
 }
 
 #define NS_IN6ADDRSZ 16
@@ -458,17 +458,15 @@ cork_ipv6_is_valid_network(const struct cork_ipv6 *addr,
 /*** IP ***/
 
 void
-cork_ip_from_ipv4(struct cork_ip *addr, const void *src)
+cork_ip_from_ipv4_(struct cork_ip *addr, const void *src)
 {
-    addr->version = 4;
-    cork_ipv4_copy(&addr->ip.v4, src);
+    cork_ip_from_ipv4(addr, src);
 }
 
 void
-cork_ip_from_ipv6(struct cork_ip *addr, const void *src)
+cork_ip_from_ipv6_(struct cork_ip *addr, const void *src)
 {
-    addr->version = 6;
-    cork_ipv6_copy(&addr->ip.v6, src);
+    cork_ip_from_ipv6(addr, src);
 }
 
 int
@@ -501,30 +499,9 @@ cork_ip_init(struct cork_ip *addr, const char *str)
 }
 
 bool
-cork_ip_equal(const struct cork_ip *addr1, const struct cork_ip *addr2)
+cork_ip_equal_(const struct cork_ip *addr1, const struct cork_ip *addr2)
 {
-    if (addr1 == addr2) {
-        return true;
-    }
-
-    if (!addr1 || !addr2) {
-        return false;
-    }
-
-    if (addr1->version != addr2->version) {
-        return false;
-    }
-
-    switch (addr1->version) {
-        case 4:
-            return cork_ipv4_equal(&addr1->ip.v4, &addr2->ip.v4);
-
-        case 6:
-            return cork_ipv6_equal(&addr1->ip.v6, &addr2->ip.v6);
-
-        default:
-            return false;
-    }
+    return cork_ip_equal(addr1, addr2);
 }
 
 void


### PR DESCRIPTION
Several of the IP address functions (`equal`, `copy`, `from_ipv[46]`) are really simple.  It would be nice to have macro (or static inline) versions of those functions so they can be inlined into their callers.
