### PR TITLE
Power-of-2 number of hash table bins

### DIFF
--- a/docs/hash-table.rst
+++ b/docs/hash-table.rst
@@ -66,6 +66,15 @@ you dispose of the hash table.
 
    Translates a key pointer into a :c:type:`cork_hash` hash value.
 
+   .. note::
+
+      It's important to use a hash function that has a uniform distribution of
+      hash values for the set of values you expect to use as hash table keys.
+      In particular, you *should not* rely on there being a prime number of hash
+      table bins to get the desired uniform distribution.  The :ref:`hash value
+      functions <hash-values>` that we provide have uniform distribution, and
+      should be safe to use for most key types.
+
 .. type:: bool (\*cork_hash_table_comparator)(const void \*key1, const void \*key2)
 
    Compares two key pointers for equality.

--- a/src/libcork/ds/hash-table.c
+++ b/src/libcork/ds/hash-table.c
@@ -40,59 +40,24 @@
  * number of bins. */
 #define CORK_HASH_TABLE_MAX_DENSITY  5
 
-/* A table of prime numbers, each greater than a power of two.  @details
- * @$ 2^n + a, 2 <= n <= 30 @$. */
-static size_t  CORK_HASH_TABLE_PRIMES[] =
-{
-    8 + 3,
-    16 + 3,
-    32 + 5,
-    64 + 3,
-    128 + 3,
-    256 + 27,
-    512 + 9,
-    1024 + 9,
-    2048 + 5,
-    4096 + 3,
-    8192 + 27,
-    16384 + 43,
-    32768 + 3,
-    65536 + 45,
-    131072 + 29,
-    262144 + 3,
-    524288 + 21,
-    1048576 + 7,
-    2097152 + 17,
-    4194304 + 15,
-    8388608 + 9,
-    16777216 + 43,
-    33554432 + 35,
-    67108864 + 15,
-    134217728 + 29,
-    268435456 + 3,
-    536870912 + 11,
-    1073741824 + 85,
-    0
-};
-
-#define CORK_HASH_TABLE_PRIME_COUNT \
-    (sizeof(CORK_HASH_TABLE_PRIMES) / sizeof(CORK_HASH_TABLE_PRIMES[0]))
-
-/* Return a prime number bin count that's at least as big as the given
- * requested size. */
-static size_t
+/* Return a power-of-2 bin count that's at least as big as the given requested
+ * size. */
+static inline size_t
 cork_hash_table_new_size(size_t desired_count)
 {
-    size_t  new_size = CORK_HASH_TABLE_DEFAULT_INITIAL_SIZE;
-    unsigned int  i;
-    for (i = 0; i < CORK_HASH_TABLE_PRIME_COUNT; i++, new_size <<= 1) {
-        if (new_size > desired_count) {
-            return CORK_HASH_TABLE_PRIMES[i];
-        }
+    size_t  v = desired_count;
+    size_t  r = 1;
+    while (v >>= 1) {
+        r <<= 1;
     }
-
-    return 0;
+    if (r != desired_count) {
+        r <<= 1;
+    }
+    return r;
 }
+
+#define bin_index(table, hash) \
+    ((hash) & ((table)->bin_count - 1))
 
 /* Allocates a new bins array in a hash table.  We overwrite the old
  * array, so make sure to stash it away somewhere safe first. */
@@ -200,7 +165,7 @@ cork_hash_table_ensure_size(struct cork_hash_table *table,
                         (curr, struct cork_hash_table_entry, siblings);
                     struct cork_dllist_item  *next = curr->next;
 
-                    size_t  bin_index = entry->hash % table->bin_count;
+                    size_t  bin_index = bin_index(table, entry->hash);
                     DEBUG("      Rehashing %p from bin %zu to bin %zu",
                           entry, i, bin_index);
                     cork_dllist_add(&table->bins[bin_index], curr);
@@ -234,7 +199,7 @@ cork_hash_table_get_entry(const struct cork_hash_table *table, const void *key)
         return NULL;
     }
 
-    size_t  bin_index = hash_value % table->bin_count;
+    size_t  bin_index = bin_index(table, hash_value);
     DEBUG("(get) Searching for key %p (hash 0x%lx, bin %zu)",
           key, (unsigned long) hash_value, bin_index);
 
@@ -279,7 +244,7 @@ cork_hash_table_get_or_create(struct cork_hash_table *table,
     size_t  bin_index;
 
     if (table->bin_count > 0) {
-        bin_index = hash_value % table->bin_count;
+        bin_index = bin_index(table, hash_value);
         DEBUG("(get_or_create) Searching for key %p (hash 0x%lx, bin %zu)",
               key, (unsigned long) hash_value, bin_index);
 
@@ -307,14 +272,14 @@ cork_hash_table_get_or_create(struct cork_hash_table *table,
         if ((table->entry_count / table->bin_count) >
             CORK_HASH_TABLE_MAX_DENSITY) {
             cork_hash_table_rehash(table);
-            bin_index = hash_value % table->bin_count;
+            bin_index = bin_index(table, hash_value);
         }
     } else {
         DEBUG("(get_or_create) Searching for key %p (hash 0x%lx)",
               key, (unsigned long) hash_value);
         DEBUG("  Empty table");
         cork_hash_table_rehash(table);
-        bin_index = hash_value % table->bin_count;
+        bin_index = bin_index(table, hash_value);
     }
 
     DEBUG("    Allocating new entry");
@@ -344,7 +309,7 @@ cork_hash_table_put(struct cork_hash_table *table,
     size_t  bin_index;
 
     if (table->bin_count > 0) {
-        bin_index = hash_value % table->bin_count;
+        bin_index = bin_index(table, hash_value);
         DEBUG("(put) Searching for key %p (hash 0x%lx, bin %zu)",
               key, (unsigned long) hash_value, bin_index);
 
@@ -385,14 +350,14 @@ cork_hash_table_put(struct cork_hash_table *table,
         if ((table->entry_count / table->bin_count) >
             CORK_HASH_TABLE_MAX_DENSITY) {
             cork_hash_table_rehash(table);
-            bin_index = hash_value % table->bin_count;
+            bin_index = bin_index(table, hash_value);
         }
     } else {
         DEBUG("(put) Searching for key %p (hash 0x%lx)",
               key, (unsigned long) hash_value);
         DEBUG("  Empty table");
         cork_hash_table_rehash(table);
-        bin_index = hash_value % table->bin_count;
+        bin_index = bin_index(table, hash_value);
     }
 
     DEBUG("    Allocating new entry");
@@ -432,7 +397,7 @@ cork_hash_table_delete(struct cork_hash_table *table, const void *key,
         return false;
     }
 
-    size_t  bin_index = hash_value % table->bin_count;
+    size_t  bin_index = bin_index(table, hash_value);
     DEBUG("(delete) Searching for key %p (hash 0x%lx, bin %zu)",
           key, (unsigned long) hash_value, bin_index);
 


### PR DESCRIPTION
Right now, our hash table implementation allocates a prime number of hash table bins.  We're using a hash function that has uniform distribution without relying on a prime number of bins.  Switching to a power-of-2 number of bins will give us a speed gain, since we can replace some modulo operations with logical-ANDs.
