### PR TITLE
Use memory pools in hash table

### DIFF
--- a/include/libcork/ds/hash-table.h
+++ b/include/libcork/ds/hash-table.h
@@ -13,6 +13,7 @@
 
 
 #include <libcork/core/hash.h>
+#include <libcork/core/mempool.h>
 #include <libcork/core/types.h>
 #include <libcork/ds/dllist.h>
 
@@ -46,6 +47,8 @@ struct cork_hash_table {
     cork_hash_table_hasher  hasher;
     /* A comparator function. */
     cork_hash_table_comparator  comparator;
+    /* A memory pool for the hash table entries */
+    struct cork_mempool  entry_mempool;
 };
 
 


### PR DESCRIPTION
We can use a memory pool to allocate the entries that are stored in a hash table.  Should give us a bit of a speedup.  It will come at the cost of an ABI incompatibility, however.
