### PR TITLE
More hash functions

### DIFF
--- a/docs/hash-values.rst
+++ b/docs/hash-values.rst
@@ -12,16 +12,14 @@ Hash values
 
 
 The functions in this section can be used to produce fast, good hash
-values.  The implementation provides by these functions can change over
-time, and doesn't have to be consistent across different platforms.  The
-only guarantee is that hash values will be consistest for the duration
-of the current process.
+values.
 
 .. note::
 
    For the curious, libcork currently uses the public-domain
    `MurmurHash3 <http://code.google.com/p/smhasher/>`_ as its hash
    implementation.
+
 
 Hashing in C code
 -----------------
@@ -59,14 +57,32 @@ this using the :ref:`cork-hash <cork-hash>` script described below::
 .. type:: uint32_t  cork_hash
 
 .. function:: cork_hash cork_hash_buffer(cork_hash seed, const void \*src, size_t len)
+              cork_hash cork_hash_variable(cork_hash seed, TYPE val)
 
-   Incorporate the contents of the given binary buffer into a hash
-   value.
+   Incorporate the contents of the given binary buffer or variable into a hash
+   value.  For the ``_variable`` variant, *val* must be an lvalue visible in the
+   current scope.
 
-.. function:: cork_hash cork_hash_variable(cork_hash seed, TYPE val)
+   The hash values produces by these functions can change over time, and might
+   not be consistent across different platforms.  The only guarantee is that
+   hash values will be consistest for the duration of the current process.
 
-   Incorporate the contents of a variable into the hash value.  *val*
-   must be an lvalue visible in the current scope.
+.. function:: cork_hash cork_stable_hash_buffer(cork_hash seed, const void \*src, size_t len)
+              cork_hash cork_stable_hash_variable(cork_hash seed, TYPE val)
+
+   Stable versions of :c:func:`cork_hash_buffer` and
+   :c:func:`cork_hash_variable`.  We guarantee that the hash values produced by
+   this function will be consistent across different platforms, and across
+   different versions of the libcork library.
+
+
+.. type:: struct cork_big_hash
+
+.. function:: void cork_big_hash_buffer(cork_hash seed, const void \*src, size_t len, struct cork_big_hash \*dest)
+
+   Incorporate the contents of the given binary buffer into a "big" hash value.
+   A big hash value has a much larger space of possible hash values (128 bits vs
+   32).
 
 
 .. _cork-hash:

--- a/include/libcork/core/hash.h
+++ b/include/libcork/core/hash.h
@@ -12,16 +12,339 @@
 #define LIBCORK_CORE_HASH_H
 
 
+#include <libcork/core/attributes.h>
+#include <libcork/core/byte-order.h>
 #include <libcork/core/types.h>
+
+
+#ifndef CORK_HASH_ATTRIBUTES
+#define CORK_HASH_ATTRIBUTES  CORK_ATTR_UNUSED static inline
+#endif
 
 
 typedef uint32_t  cork_hash;
 
+struct cork_big_hash {
+    union {
+        uint64_t  u64[2];
+        uint32_t  u32[4];
+    } _;
+};
+
+#define cork_big_hash_equal(h1, h2) \
+    ((h1)->_.u64[0] == (h2)->_.u64[0] && (h1)->_.u64[1] == (h2)->_.u64[1])
+
+#define CORK_BIG_HASH_INIT()  {{{0,0}}}
+
+/* We currently use MurmurHash3 [1], which is public domain, as our hash
+ * implementation.
+ *
+ * [1] http://code.google.com/p/smhasher/
+ */
+
+#define CORK_ROTL32(a,b) (((a) << ((b) & 0x1f)) | ((a) >> (32 - ((b) & 0x1f))))
+#define CORK_ROTL64(a,b) (((a) << ((b) & 0x3f)) | ((a) >> (64 - ((b) & 0x3f))))
+
+CORK_ATTR_UNUSED
+static inline
+uint32_t cork_fmix32(uint32_t h)
+{
+    h ^= h >> 16;
+    h *= 0x85ebca6b;
+    h ^= h >> 13;
+    h *= 0xc2b2ae35;
+    h ^= h >> 16;
+    return h;
+}
+
+CORK_ATTR_UNUSED
+static inline
+uint64_t cork_fmix64(uint64_t k)
+{
+    k ^= k >> 33;
+    k *= UINT64_C(0xff51afd7ed558ccd);
+    k ^= k >> 33;
+    k *= UINT64_C(0xc4ceb9fe1a85ec53);
+    k ^= k >> 33;
+    return k;
+}
+
+CORK_HASH_ATTRIBUTES
 cork_hash
-cork_hash_buffer(cork_hash seed, const void *src, size_t len);
+cork_stable_hash_buffer(cork_hash seed, const void *src, size_t len)
+{
+    /* This is exactly the same as cork_murmur_hash_x86_32, but with a byte swap
+     * to make sure that we always process the uint32s little-endian. */
+    const unsigned int  nblocks = len / 4;
+    const uint32_t  *blocks = (const uint32_t *) src;
+    const uint32_t  *end = blocks + nblocks;
+    const uint32_t  *curr;
+    const uint8_t  *tail = (const uint8_t *) end;
+
+    uint32_t  h1 = seed;
+    uint32_t  c1 = 0xcc9e2d51;
+    uint32_t  c2 = 0x1b873593;
+    uint32_t  k1 = 0;
+
+    /* body */
+    for (curr = blocks; curr != end; curr++) {
+        uint32_t  k1 = CORK_UINT32_HOST_TO_LITTLE(*curr);
+
+        k1 *= c1;
+        k1 = CORK_ROTL32(k1,15);
+        k1 *= c2;
+
+        h1 ^= k1;
+        h1 = CORK_ROTL32(h1,13);
+        h1 = h1*5+0xe6546b64;
+    }
+
+    /* tail */
+    switch (len & 3) {
+        case 3: k1 ^= tail[2] << 16;
+        case 2: k1 ^= tail[1] << 8;
+        case 1: k1 ^= tail[0];
+                k1 *= c1; k1 = CORK_ROTL32(k1,15); k1 *= c2; h1 ^= k1;
+    };
+
+    /* finalization */
+    h1 ^= len;
+    h1 = cork_fmix32(h1);
+    return h1;
+}
+
+#define cork_murmur_hash_x86_32(seed, src, len, dest) \
+do { \
+    const unsigned int  nblocks = len / 4; \
+    const uint32_t  *blocks = (const uint32_t *) src; \
+    const uint32_t  *end = blocks + nblocks; \
+    const uint32_t  *curr; \
+    const uint8_t  *tail = (const uint8_t *) end; \
+    \
+    uint32_t  h1 = seed; \
+    uint32_t  c1 = 0xcc9e2d51; \
+    uint32_t  c2 = 0x1b873593; \
+    uint32_t  k1 = 0; \
+    \
+    /* body */ \
+    for (curr = blocks; curr != end; curr++) { \
+        uint32_t  k1 = *curr; \
+        \
+        k1 *= c1; \
+        k1 = CORK_ROTL32(k1,15); \
+        k1 *= c2; \
+        \
+        h1 ^= k1; \
+        h1 = CORK_ROTL32(h1,13); \
+        h1 = h1*5+0xe6546b64; \
+    } \
+    \
+    /* tail */ \
+    switch (len & 3) { \
+        case 3: k1 ^= tail[2] << 16; \
+        case 2: k1 ^= tail[1] << 8; \
+        case 1: k1 ^= tail[0]; \
+                k1 *= c1; k1 = CORK_ROTL32(k1,15); k1 *= c2; h1 ^= k1; \
+    }; \
+    \
+    /* finalization */ \
+    h1 ^= len; \
+    h1 = cork_fmix32(h1); \
+    *(dest) = h1; \
+} while (0)
+
+#define cork_murmur_hash_x86_128(seed, src, len, dest) \
+do { \
+    const int  nblocks = len / 16; \
+    const uint32_t  *blocks = (const uint32_t *) src; \
+    const uint32_t  *end = blocks + (nblocks * 4); \
+    const uint32_t  *curr; \
+    const uint8_t  *tail = (const uint8_t *) end; \
+    \
+    uint32_t  h1 = seed; \
+    uint32_t  h2 = seed; \
+    uint32_t  h3 = seed; \
+    uint32_t  h4 = seed; \
+    \
+    uint32_t  c1 = 0x239b961b; \
+    uint32_t  c2 = 0xab0e9789; \
+    uint32_t  c3 = 0x38b34ae5; \
+    uint32_t  c4 = 0xa1e38b93; \
+    \
+    uint32_t  k1 = 0; \
+    uint32_t  k2 = 0; \
+    uint32_t  k3 = 0; \
+    uint32_t  k4 = 0; \
+    \
+    /* body */ \
+    for (curr = blocks; curr != end; curr += 4) { \
+        uint32_t  k1 = curr[0]; \
+        uint32_t  k2 = curr[1]; \
+        uint32_t  k3 = curr[2]; \
+        uint32_t  k4 = curr[3]; \
+        \
+        k1 *= c1; k1  = CORK_ROTL32(k1,15); k1 *= c2; h1 ^= k1; \
+        h1 = CORK_ROTL32(h1,19); h1 += h2; h1 = h1*5+0x561ccd1b; \
+        \
+        k2 *= c2; k2  = CORK_ROTL32(k2,16); k2 *= c3; h2 ^= k2; \
+        h2 = CORK_ROTL32(h2,17); h2 += h3; h2 = h2*5+0x0bcaa747; \
+        \
+        k3 *= c3; k3  = CORK_ROTL32(k3,17); k3 *= c4; h3 ^= k3; \
+        h3 = CORK_ROTL32(h3,15); h3 += h4; h3 = h3*5+0x96cd1c35; \
+        \
+        k4 *= c4; k4  = CORK_ROTL32(k4,18); k4 *= c1; h4 ^= k4; \
+        h4 = CORK_ROTL32(h4,13); h4 += h1; h4 = h4*5+0x32ac3b17; \
+    } \
+    \
+    /* tail */ \
+    switch (len & 15) { \
+        case 15: k4 ^= tail[14] << 16; \
+        case 14: k4 ^= tail[13] << 8; \
+        case 13: k4 ^= tail[12] << 0; \
+                 k4 *= c4; k4 = CORK_ROTL32(k4,18); k4 *= c1; h4 ^= k4; \
+        \
+        case 12: k3 ^= tail[11] << 24; \
+        case 11: k3 ^= tail[10] << 16; \
+        case 10: k3 ^= tail[ 9] << 8; \
+        case  9: k3 ^= tail[ 8] << 0; \
+                 k3 *= c3; k3 = CORK_ROTL32(k3,17); k3 *= c4; h3 ^= k3; \
+        \
+        case  8: k2 ^= tail[ 7] << 24; \
+        case  7: k2 ^= tail[ 6] << 16; \
+        case  6: k2 ^= tail[ 5] << 8; \
+        case  5: k2 ^= tail[ 4] << 0; \
+                 k2 *= c2; k2 = CORK_ROTL32(k2,16); k2 *= c3; h2 ^= k2; \
+        \
+        case  4: k1 ^= tail[ 3] << 24; \
+        case  3: k1 ^= tail[ 2] << 16; \
+        case  2: k1 ^= tail[ 1] << 8; \
+        case  1: k1 ^= tail[ 0] << 0; \
+                 k1 *= c1; k1 = CORK_ROTL32(k1,15); k1 *= c2; h1 ^= k1; \
+    }; \
+    \
+    /* finalization */ \
+    \
+    h1 ^= len; h2 ^= len; h3 ^= len; h4 ^= len; \
+    \
+    h1 += h2; h1 += h3; h1 += h4; \
+    h2 += h1; h3 += h1; h4 += h1; \
+    \
+    h1 = cork_fmix32(h1); \
+    h2 = cork_fmix32(h2); \
+    h3 = cork_fmix32(h3); \
+    h4 = cork_fmix32(h4); \
+    \
+    h1 += h2; h1 += h3; h1 += h4; \
+    h2 += h1; h3 += h1; h4 += h1; \
+    \
+    (dest)->_.u32[0] = h1; \
+    (dest)->_.u32[1] = h2; \
+    (dest)->_.u32[2] = h3; \
+    (dest)->_.u32[3] = h4; \
+} while (0)
+
+#define cork_murmur_hash_x64_128(seed, src, len, dest) \
+do { \
+    const int  nblocks = len / 16; \
+    const uint64_t  *blocks = (const uint64_t *) src; \
+    const uint64_t  *end = blocks + (nblocks * 2); \
+    const uint64_t  *curr; \
+    const uint8_t  *tail = (const uint8_t *) end; \
+    \
+    uint64_t  h1 = (((uint64_t) seed) << 32) | seed; \
+    uint64_t  h2 = (((uint64_t) seed) << 32) | seed; \
+    \
+    uint64_t  c1 = UINT64_C(0x87c37b91114253d5); \
+    uint64_t  c2 = UINT64_C(0x4cf5ad432745937f); \
+    \
+    uint64_t k1 = 0; \
+    uint64_t k2 = 0; \
+    \
+    /* body */ \
+    for (curr = blocks; curr != end; curr += 2) { \
+        uint64_t  k1 = curr[0]; \
+        uint64_t  k2 = curr[1]; \
+    \
+        k1 *= c1; k1  = CORK_ROTL64(k1,31); k1 *= c2; h1 ^= k1; \
+        h1 = CORK_ROTL64(h1,27); h1 += h2; h1 = h1*5+0x52dce729; \
+    \
+        k2 *= c2; k2  = CORK_ROTL64(k2,33); k2 *= c1; h2 ^= k2; \
+        h2 = CORK_ROTL64(h2,31); h2 += h1; h2 = h2*5+0x38495ab5; \
+    } \
+    \
+    /* tail */ \
+    switch (len & 15) { \
+        case 15: k2 ^= (uint64_t) (tail[14]) << 48; \
+        case 14: k2 ^= (uint64_t) (tail[13]) << 40; \
+        case 13: k2 ^= (uint64_t) (tail[12]) << 32; \
+        case 12: k2 ^= (uint64_t) (tail[11]) << 24; \
+        case 11: k2 ^= (uint64_t) (tail[10]) << 16; \
+        case 10: k2 ^= (uint64_t) (tail[ 9]) << 8; \
+        case  9: k2 ^= (uint64_t) (tail[ 8]) << 0; \
+                 k2 *= c2; k2 = CORK_ROTL64(k2,33); k2 *= c1; h2 ^= k2; \
+        \
+        case  8: k1 ^= (uint64_t) (tail[ 7]) << 56; \
+        case  7: k1 ^= (uint64_t) (tail[ 6]) << 48; \
+        case  6: k1 ^= (uint64_t) (tail[ 5]) << 40; \
+        case  5: k1 ^= (uint64_t) (tail[ 4]) << 32; \
+        case  4: k1 ^= (uint64_t) (tail[ 3]) << 24; \
+        case  3: k1 ^= (uint64_t) (tail[ 2]) << 16; \
+        case  2: k1 ^= (uint64_t) (tail[ 1]) << 8; \
+        case  1: k1 ^= (uint64_t) (tail[ 0]) << 0; \
+                 k1 *= c1; k1 = CORK_ROTL64(k1,31); k1 *= c2; h1 ^= k1; \
+    }; \
+    \
+    /* finalization */ \
+    \
+    h1 ^= len; h2 ^= len; \
+    \
+    h1 += h2; \
+    h2 += h1; \
+    \
+    h1 = cork_fmix64(h1); \
+    h2 = cork_fmix64(h2); \
+    \
+    h1 += h2; \
+    h2 += h1; \
+    \
+    (dest)->_.u64[0] = h1; \
+    (dest)->_.u64[1] = h2; \
+} while (0)
+
+
+CORK_HASH_ATTRIBUTES
+cork_hash
+cork_hash_buffer(cork_hash seed, const void *src, size_t len)
+{
+#if CORK_SIZEOF_POINTER == 8
+    struct cork_big_hash  hash = CORK_BIG_HASH_INIT();
+    cork_murmur_hash_x64_128(seed, src, len, &hash);
+    return hash._.u32[0];
+#else
+    cork_hash  hash = 0;
+    cork_murmur_hash_x86_32(seed, src, len, &hash);
+    return hash;
+#endif
+}
+
+
+CORK_HASH_ATTRIBUTES
+void
+cork_big_hash_buffer(cork_hash seed, const void *src, size_t len,
+                     struct cork_big_hash *dest)
+{
+#if CORK_SIZEOF_POINTER == 8
+    cork_murmur_hash_x64_128(seed, src, len, dest);
+#else
+    cork_murmur_hash_x86_128(seed, src, len, dest);
+#endif
+}
+
 
 #define cork_hash_variable(seed, val) \
     (cork_hash_buffer((seed), &(val), sizeof((val))))
+#define cork_stable_hash_variable(seed, val) \
+    (cork_stable_hash_buffer((seed), &(val), sizeof((val))))
 
 
 #endif /* LIBCORK_CORE_HASH_H */

--- a/src/cork-hash/cork-hash.c
+++ b/src/cork-hash/cork-hash.c
@@ -26,7 +26,7 @@ main(int argc, char **argv)
 
     /* don't include NUL terminator in hash */
     result = 0;
-    result = cork_hash_buffer(result, argv[1], strlen(argv[1]));
+    result = cork_stable_hash_buffer(result, argv[1], strlen(argv[1]));
     printf("0x%08" PRIx32 "\n", result);
     return EXIT_SUCCESS;
 }

--- a/src/libcork/core/hash.c
+++ b/src/libcork/core/hash.c
@@ -8,77 +8,13 @@
  * ----------------------------------------------------------------------
  */
 
+#define CORK_HASH_ATTRIBUTES  /* not static in here! */
+
 #include "libcork/core/hash.h"
 #include "libcork/core/types.h"
 
-/*
- * We currently use MurmurHash3 [1], which is public domain, as our hash
- * implementation.
- *
- * [1] http://code.google.com/p/smhasher/
+/* All of the following functions will be defined for us by libcork/core/hash.h:
+ *   cork_hash_buffer
+ *   cork_big_hash_buffer
+ *   cork_stable_hash_buffer
  */
-
-#define ROTL32(a,b) (((a) << ((b) & 0x1f)) | ((a) >> (32 - ((b) & 0x1f))))
-
-static inline uint32_t fmix(uint32_t h)
-{
-    h ^= h >> 16;
-    h *= 0x85ebca6b;
-    h ^= h >> 13;
-    h *= 0xc2b2ae35;
-    h ^= h >> 16;
-    return h;
-}
-
-cork_hash
-cork_hash_buffer(cork_hash seed, const void *src, size_t len)
-{
-    const uint8_t  *data = (const uint8_t *) src;
-    const int  nblocks = len / 4;
-
-    uint32_t  h1 = seed;
-
-    uint32_t  c1 = 0xcc9e2d51;
-    uint32_t  c2 = 0x1b873593;
-
-    //----------
-    // body
-
-    const uint32_t  *blocks = (const uint32_t *) (data + nblocks*4);
-    int  i;
-
-    for (i = -nblocks; i != 0; i++) {
-        uint32_t  k1 = blocks[i];
-
-        k1 *= c1;
-        k1 = ROTL32(k1,15);
-        k1 *= c2;
-
-        h1 ^= k1;
-        h1 = ROTL32(h1,13);
-        h1 = h1*5+0xe6546b64;
-    }
-
-    //----------
-    // tail
-
-    const uint8_t  *tail = (const uint8_t *) (data + nblocks*4);
-
-    uint32_t  k1 = 0;
-
-    switch (len & 3)
-    {
-        case 3: k1 ^= tail[2] << 16;
-        case 2: k1 ^= tail[1] << 8;
-        case 1: k1 ^= tail[0];
-                k1 *= c1; k1 = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
-    };
-
-    //----------
-    // finalization
-
-    h1 ^= len;
-
-    h1 = fmix(h1);
-    return h1;
-}


### PR DESCRIPTION
Our hash implementation is based on [MurmurHash3](https://code.google.com/p/smhasher/wiki/MurmurHash3).  Right now we're only using the function that generates a 32-bit hash using 32-bit instructions.  There's also a 128-bit hash function, as well as an optimized version of that for 64-bit architectures.  It would be nice to have those available in libcork as well.

Also, the API docs currently state that there's no guarantee that the hash value will be consistent across platforms.  We should make a version where we do guarantee that.  It can use the existing 32-bit implementation, normalizing for endianness.  The `cork-hash` program should use this stable hash function.
