### PR TITLE
Hash tables with string keys

### DIFF
--- a/docs/hash-table.rst
+++ b/docs/hash-table.rst
@@ -115,6 +115,29 @@ you dispose of the hash table.
       read-only.
 
 
+Built-in key types
+------------------
+
+With the :c:func:`cork_hash_table_init` and :c:func:`cork_hash_table_new`
+functions, you must provide hasher and comparator functions for the keys that
+you're going to use in the hash table.  To save you from effort, we also provide
+a handful of specialized constructors for common key types.
+
+
+.. function:: void cork_string_hash_table_init(struct cork_hash_table \*table, size_t initial_size)
+              struct cork_hash_table \*cork_string_hash_table_new(size_t initial_size)
+
+   Create a hash table whose keys will be C strings.
+
+
+.. function:: void cork_pointer_hash_table_init(struct cork_hash_table \*table, size_t initial_size)
+              struct cork_hash_table \*cork_pointer_hash_table_new(size_t initial_size)
+
+   Create a hash table where keys should be compared using standard pointer
+   equality.  (In other words, keys should only be considered equal if they
+   point to the same physical object.)
+
+
 Adding and retrieving entries
 -----------------------------
 

--- a/include/libcork/ds/hash-table.h
+++ b/include/libcork/ds/hash-table.h
@@ -18,6 +18,10 @@
 #include <libcork/ds/dllist.h>
 
 
+/*-----------------------------------------------------------------------
+ * Hash tables
+ */
+
 typedef cork_hash
 (*cork_hash_table_hasher)(const void *key);
 
@@ -135,6 +139,24 @@ cork_hash_table_iterator_init(struct cork_hash_table *table,
 
 struct cork_hash_table_entry *
 cork_hash_table_iterator_next(struct cork_hash_table_iterator *iterator);
+
+
+/*-----------------------------------------------------------------------
+ * Built-in key types
+ */
+
+void
+cork_string_hash_table_init(struct cork_hash_table *table, size_t initial_size);
+
+struct cork_hash_table *
+cork_string_hash_table_new(size_t initial_size);
+
+void
+cork_pointer_hash_table_init(struct cork_hash_table *table,
+                              size_t initial_size);
+
+struct cork_hash_table *
+cork_pointer_hash_table_new(size_t initial_size);
 
 
 #endif /* LIBCORK_DS_HASH_TABLE_H */

--- a/src/libcork/ds/hash-table.c
+++ b/src/libcork/ds/hash-table.c
@@ -34,6 +34,10 @@
 #endif
 
 
+/*-----------------------------------------------------------------------
+ * Hash tables
+ */
+
 /* The default initial number of bins to allocate in a new table. */
 #define CORK_HASH_TABLE_DEFAULT_INITIAL_SIZE  8
 
@@ -528,4 +532,64 @@ cork_hash_table_iterator_next(struct cork_hash_table_iterator *iterator)
     DEBUG("    Returning entry %p", result);
     iterator->curr = iterator->curr->next;
     return result;
+}
+
+
+/*-----------------------------------------------------------------------
+ * Built-in key types
+ */
+
+static cork_hash
+string_hasher(const void *vk)
+{
+    const char  *k = vk;
+    size_t  len = strlen(k);
+    return cork_hash_buffer(0, k, len);
+}
+
+static bool
+string_comparator(const void *vk1, const void *vk2)
+{
+    const char  *k1 = vk1;
+    const char  *k2 = vk2;
+    return strcmp(k1, k2) == 0;
+}
+
+void
+cork_string_hash_table_init(struct cork_hash_table *table, size_t initial_size)
+{
+    cork_hash_table_init(table, initial_size, string_hasher, string_comparator);
+}
+
+struct cork_hash_table *
+cork_string_hash_table_new(size_t initial_size)
+{
+    return cork_hash_table_new(initial_size, string_hasher, string_comparator);
+}
+
+static cork_hash
+pointer_hasher(const void *vk)
+{
+    return (cork_hash) (uintptr_t) vk;
+}
+
+static bool
+pointer_comparator(const void *vk1, const void *vk2)
+{
+    return vk1 == vk2;
+}
+
+void
+cork_pointer_hash_table_init(struct cork_hash_table *table,
+                              size_t initial_size)
+{
+    cork_hash_table_init
+        (table, initial_size, pointer_hasher, pointer_comparator);
+}
+
+struct cork_hash_table *
+cork_pointer_hash_table_new(size_t initial_size)
+{
+    return cork_hash_table_new
+        (initial_size, pointer_hasher, pointer_comparator);
 }

--- a/tests/test-hash-table.c
+++ b/tests/test-hash-table.c
@@ -22,7 +22,7 @@
 #include "helpers.h"
 
 /*-----------------------------------------------------------------------
- * Hash tables
+ * Integer hash tables
  */
 
 static bool
@@ -92,7 +92,7 @@ test_iterator_sum(struct cork_hash_table *table, uint64_t expected)
                 sum, expected);
 }
 
-START_TEST(test_hash_table)
+START_TEST(test_uint64_hash_table)
 {
     struct cork_hash_table  *table;
     fail_if_error(table = cork_hash_table_new
@@ -228,6 +228,71 @@ END_TEST
 
 
 /*-----------------------------------------------------------------------
+ * String hash tables
+ */
+
+START_TEST(test_string_hash_table)
+{
+    struct cork_hash_table  *table;
+    char  key[256];
+    void  *value;
+
+    fail_if_error(table = cork_string_hash_table_new(0));
+
+    fail_if_error(cork_hash_table_put
+                  (table, "key1", (void *) (uintptr_t) 1, NULL, NULL, NULL));
+    fail_unless(cork_hash_table_size(table) == 1,
+                "Unexpected size after adding {key1->1}");
+
+    strncpy(key, "key1", sizeof(key));
+    fail_if((value = cork_hash_table_get(table, key)) == NULL,
+            "No entry for key1");
+
+    fail_unless(value == (void *) (uintptr_t) 1,
+                "Unexpected value for key1");
+
+    strncpy(key, "key2", sizeof(key));
+    fail_unless((value = cork_hash_table_get(table, key)) == NULL,
+                "Unexpected entry for key2");
+
+    cork_hash_table_free(table);
+}
+END_TEST
+
+
+/*-----------------------------------------------------------------------
+ * Pointer hash tables
+ */
+
+START_TEST(test_pointer_hash_table)
+{
+    struct cork_hash_table  *table;
+    int  key1;
+    int  key2;
+    void  *value;
+
+    fail_if_error(table = cork_pointer_hash_table_new(0));
+
+    fail_if_error(cork_hash_table_put
+                  (table, &key1, (void *) (uintptr_t) 1, NULL, NULL, NULL));
+    fail_unless(cork_hash_table_size(table) == 1,
+                "Unexpected size after adding {key1->1}");
+
+    fail_if((value = cork_hash_table_get(table, &key1)) == NULL,
+            "No entry for key1");
+
+    fail_unless(value == (void *) (uintptr_t) 1,
+                "Unexpected value for key1");
+
+    fail_unless((value = cork_hash_table_get(table, &key2)) == NULL,
+                "Unexpected entry for key2");
+
+    cork_hash_table_free(table);
+}
+END_TEST
+
+
+/*-----------------------------------------------------------------------
  * Testing harness
  */
 
@@ -237,7 +302,9 @@ test_suite()
     Suite  *s = suite_create("hash_table");
 
     TCase  *tc_ds = tcase_create("hash_table");
-    tcase_add_test(tc_ds, test_hash_table);
+    tcase_add_test(tc_ds, test_uint64_hash_table);
+    tcase_add_test(tc_ds, test_string_hash_table);
+    tcase_add_test(tc_ds, test_pointer_hash_table);
     suite_add_tcase(s, tc_ds);
 
     return s;


### PR DESCRIPTION
Most of the time that I use `cork_hash_table`, I'm using C strings as keys.  Let's provide a pre-canned constructor for that.
