### PR TITLE
Library initializer functions

### DIFF
--- a/docs/attributes.rst
+++ b/docs/attributes.rst
@@ -98,3 +98,22 @@ common compiler attributes.
      {
          CORK_ATTR_UNUSED int  unused_value;
      }
+
+
+.. macro:: CORK_INITIALIZER(func_name)
+
+   Declare a ``static`` function that will be automatically called at program
+   startup.  If there are multiple initializer functions linked into a program,
+   there is no guarantee about the order in which the functions will be called.
+
+   ::
+
+     #include <libcork/core.h>
+     #include <libcork/ds.h>
+
+     static cork_array(int)  array;
+
+     CORK_INITIALIZER(init_array)
+     {
+        cork_array_init(&array);
+     }

--- a/include/libcork/core/attributes.h
+++ b/include/libcork/core/attributes.h
@@ -133,4 +133,25 @@
 #endif
 
 
+/*
+ * Declare a static function that should automatically be called at program
+ * startup.
+ */
+
+/* TODO: When we implement a full Windows port, [1] describes how best to
+ * implement an initialization function under Visual Studio.
+ *
+ * [1] http://stackoverflow.com/questions/1113409/attribute-constructor-equivalent-in-vc
+ */
+
+#if CORK_CONFIG_HAVE_GCC_ATTRIBUTES
+#define CORK_INITIALIZER(name) \
+__attribute__((constructor)) \
+static void \
+name(void)
+#else
+#error "Don't know how to implement initialization functions of this platform"
+#endif
+
+
 #endif /* LIBCORK_CORE_ATTRIBUTES_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,14 @@ set(CORK_HASH_SRC cork-hash/cork-hash.c)
 add_executable(cork-hash ${CORK_HASH_SRC})
 target_link_libraries(cork-hash embedded_libcork)
 
+set(CORK_INITIALIZER_SRC
+    cork-initializer/init1.c
+    cork-initializer/init2.c
+    cork-initializer/main.c
+)
+add_executable(cork-initializer ${CORK_INITIALIZER_SRC})
+target_link_libraries(cork-initializer embedded_libcork)
+
 set(CORK_TEST_SRC cork-test/cork-test.c)
 add_executable(cork-test ${CORK_TEST_SRC})
 target_link_libraries(cork-test embedded_libcork)

--- a/src/cork-initializer/init1.c
+++ b/src/cork-initializer/init1.c
@@ -1,0 +1,18 @@
+/* -*- coding: utf-8 -*-
+ * ----------------------------------------------------------------------
+ * Copyright © 2012, RedJack, LLC.
+ * All rights reserved.
+ *
+ * Please see the COPYING file in this distribution for license
+ * details.
+ * ----------------------------------------------------------------------
+ */
+
+#include <stdio.h>
+
+#include <libcork/core.h>
+
+CORK_INITIALIZER(init)
+{
+    printf("Initializer 1\n");
+}

--- a/src/cork-initializer/init2.c
+++ b/src/cork-initializer/init2.c
@@ -1,0 +1,18 @@
+/* -*- coding: utf-8 -*-
+ * ----------------------------------------------------------------------
+ * Copyright © 2012, RedJack, LLC.
+ * All rights reserved.
+ *
+ * Please see the COPYING file in this distribution for license
+ * details.
+ * ----------------------------------------------------------------------
+ */
+
+#include <stdio.h>
+
+#include <libcork/core.h>
+
+CORK_INITIALIZER(init)
+{
+    printf("Initializer 2\n");
+}

--- a/src/cork-initializer/main.c
+++ b/src/cork-initializer/main.c
@@ -1,0 +1,15 @@
+/* -*- coding: utf-8 -*-
+ * ----------------------------------------------------------------------
+ * Copyright © 2012, RedJack, LLC.
+ * All rights reserved.
+ *
+ * Please see the COPYING file in this distribution for license
+ * details.
+ * ----------------------------------------------------------------------
+ */
+
+int
+main(int argc, char **argv)
+{
+    return 0;
+}

--- a/tests/cork-initializer.t
+++ b/tests/cork-initializer.t
@@ -1,0 +1,6 @@
+We need to sort the output, since there's no guarantee about which order our
+initializer functions will run in.
+
+  $ cork-initializer | sort
+  Initializer 1
+  Initializer 2


### PR DESCRIPTION
I'd like to expose a new libcork macro for defining initialization functions — a function that's automatically called at program startup time.  (Before `main`.)  On GCC, you do that using the [`constructor` attribute](http://gcc.gnu.org/onlinedocs/gcc/Function-Attributes.html#index-g_t_0040code_007bconstructor_007d-function-attribute-2570).  This [StackOverflow post](http://stackoverflow.com/questions/1113409/attribute-constructor-equivalent-in-vc) describes the equivalent in Visual Studio, for when we do a proper Windows port.
