### PR TITLE
Symbol visibility macros

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ Contents
    :maxdepth: 2
 
    config
+   visibility
    basic-types
    byte-order
    attributes

--- a/docs/visibility.rst
+++ b/docs/visibility.rst
@@ -1,0 +1,121 @@
+.. _visibility:
+
+*****************
+Symbol visibility
+*****************
+
+.. highlight:: c
+
+::
+
+  #include <libcork/core.h>
+
+When writing a shared library, you should always be careful to explicitly mark
+which functions and other symbols are part of the library's public API, and
+which should only be used internally by the library.  There are a number of
+benefits to doing this; there is a good summary on the `GCC wiki`_.  (Note that
+even though that summary is on the GCC wiki, the notes apply equally well to
+other compilers and platforms.)
+
+.. _GCC wiki: http://gcc.gnu.org/wiki/Visibility
+
+libcork provides several helper macros that make it easier to do this.  We use
+these macros ourselves to define libcork's public API.
+
+
+Defining a library's public API
+-------------------------------
+
+On some platforms (for instance, on Windows), you must declare each public
+function and symbol differently depending on whether you're compiling the
+library that *defines* the symbol, or a library or program that *uses* the
+symbol.  The first is called an *export*, the second an *import*.  On other
+platforms (for instance, GCC on Linux), the declaration of a public symbol is
+the same regardless of whether you're exporting or importing the symbol.
+libcork provides macros that let you explicitly declare a symbol as an export or
+an import in a platform-independent way.
+
+.. macro:: CORK_EXPORT
+           CORK_IMPORT
+
+   Explicitly declare that a symbol should be exported from the current shared
+   library, or imported from some other shared library.
+
+However, you will rarely need to use these macros directly.  Instead, when
+writing a new shared library, you should declare a new preprocessor macro
+(specific to the new library), which you'll use when declaring the library's
+public API.  For instance, if you're creating a new library called
+*libfoo*, you would declare a new preprocessor macro called ``FOO_API``::
+
+    #if !defined(FOO_API)
+    #define FOO_API  CORK_IMPORT
+    #endif
+
+This ensures that anyone who wants to *use* libfoo doesn't need to do anything
+special; the ``FOO_API`` macro will default to importing the symbols from
+libfoo's public API.
+
+When *building* libfoo, you must set up your build system to define this
+variable differently; since you need to *export* the symbols in this case, the
+``FOO_API`` macro should be set to ``CORK_EXPORT``.  Each build system will have
+a different way to do this.  In CMake, for instance, you'd add the following:
+
+.. code-block:: cmake
+
+    set_target_properties(libfoo PROPERTIES
+        COMPILE_DEFINITIONS FOO_API=CORK_EXPORT
+    )
+
+Then, in all of your header files, you should use your new ``FOO_API`` macro
+when declaring each function or symbol in the public API::
+
+    FOO_API int
+    foo_load_from_file(const char *name);
+
+    FOO_API void
+    foo_do_something_great(int flags);
+
+    extern FOO_API  const char  *foo_name;
+
+
+Local symbols
+-------------
+
+Normally, if you need a function to be local, and not be exported as part of the
+library's public API, you can just declare it ``static``::
+
+    static int
+    file_local_function(void)
+    {
+        /* This function is not visible outside of this file. */
+        return 0;
+    }
+
+This works great as long as the function is only needed within the current
+source file.  Sometimes, though, you need to define a function that can be used
+in other source files within the same library, but which shouldn't be visible
+outside of the library.  To do this, you should define the function using the
+:c:macro:`CORK_LOCAL` macro.
+
+.. macro:: CORK_LOCAL
+
+   Declare a symbol that should be visible in any source file within the current
+   library, but not visible outside of the library.
+
+As an example::
+
+    CORK_LOCAL int
+    library_local_function(void)
+    {
+        /* This function is visible in other files, but not outside of the
+         * library. */
+        return 0;
+    }
+
+Since you're going to use this function in multiple files, you'll want to
+declare the function in a header file.  However, since the function is not part
+of the public API, this should *not* be defined in a public header file (that
+is, one that's installed along with the shared library).  Instead, you should
+include a private header file that's only available in your library's source
+code archive, and which should not be installed with the other public header
+files.

--- a/include/libcork/cli/commands.h
+++ b/include/libcork/cli/commands.h
@@ -11,6 +11,8 @@
 #ifndef LIBCORK_COMMANDS_H
 #define LIBCORK_COMMANDS_H
 
+#include <libcork/core/api.h>
+
 
 typedef void
 (*cork_leaf_command_run)(int argc, char **argv);
@@ -49,10 +51,10 @@ struct cork_command {
     parse_options, NULL, run \
 }
 
-void
+CORK_API void
 cork_command_show_help(struct cork_command *command, const char *message);
 
-int
+CORK_API int
 cork_command_main(struct cork_command *root, int argc, char **argv);
 
 

--- a/include/libcork/core/allocator.h
+++ b/include/libcork/core/allocator.h
@@ -13,6 +13,7 @@
 
 #include <stdlib.h>
 
+#include <libcork/core/api.h>
 #include <libcork/core/attributes.h>
 #include <libcork/core/error.h>
 #include <libcork/core/types.h>
@@ -29,7 +30,7 @@
 #if CORK_HAVE_REALLOCF
 #define cork_xrealloc  reallocf
 #else
-void *
+CORK_API void *
 cork_xrealloc(void *ptr, size_t new_size) CORK_ATTR_MALLOC;
 #endif
 
@@ -38,10 +39,10 @@ cork_xrealloc(void *ptr, size_t new_size) CORK_ATTR_MALLOC;
 
 /* string-related functions */
 
-const char *
+CORK_API const char *
 cork_xstrdup(const char *str);
 
-void
+CORK_API void
 cork_strfree(const char *str);
 
 

--- a/include/libcork/core/api.h
+++ b/include/libcork/core/api.h
@@ -1,0 +1,25 @@
+/* -*- coding: utf-8 -*-
+ * ----------------------------------------------------------------------
+ * Copyright © 2012, RedJack, LLC.
+ * All rights reserved.
+ *
+ * Please see the COPYING file in this distribution for license
+ * details.
+ * ----------------------------------------------------------------------
+ */
+
+#ifndef LIBCORK_CORE_API_H
+#define LIBCORK_CORE_API_H
+
+#include <libcork/core/attributes.h>
+
+/* If you're using libcork as a shared library, you don't need to do anything
+ * special; the following will automatically set things up so that libcork's
+ * public symbols are imported from the library.  When we build the shared
+ * library, we define this ourselves to export the symbols. */
+
+#if !defined(CORK_API)
+#define CORK_API  CORK_IMPORT
+#endif
+
+#endif /* LIBCORK_CORE_API_H */

--- a/include/libcork/core/attributes.h
+++ b/include/libcork/core/attributes.h
@@ -132,5 +132,20 @@
 #define CORK_UNLIKELY(expr)  (expr)
 #endif
 
+/*
+ * Declare that a function is part of the current library's public API, or that
+ * it's internal to the current library.
+ */
+
+#if CORK_CONFIG_HAVE_GCC_ATTRIBUTES
+#define CORK_EXPORT  __attribute__((visibility("default")))
+#define CORK_IMPORT  __attribute__((visibility("default")))
+#define CORK_LOCAL   __attribute__((visibility("hidden")))
+#else
+#define CORK_EXPORT
+#define CORK_IMPORT
+#define CORK_LOCAL
+#endif
+
 
 #endif /* LIBCORK_CORE_ATTRIBUTES_H */

--- a/include/libcork/core/error.h
+++ b/include/libcork/core/error.h
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <libcork/core/api.h>
 #include <libcork/core/attributes.h>
 #include <libcork/core/types.h>
 
@@ -26,24 +27,24 @@ typedef uint32_t  cork_error_class;
 
 typedef unsigned int  cork_error_code;
 
-bool
+CORK_API bool
 cork_error_occurred(void);
 
-cork_error_class
+CORK_API cork_error_class
 cork_error_get_class(void);
 
-cork_error_code
+CORK_API cork_error_code
 cork_error_get_code(void);
 
-const char *
+CORK_API const char *
 cork_error_message(void);
 
-void
+CORK_API void
 cork_error_set(cork_error_class error_class, cork_error_code error_code,
                const char *format, ...)
     CORK_ATTR_PRINTF(3,4);
 
-void
+CORK_API void
 cork_error_clear(void);
 
 
@@ -61,10 +62,10 @@ enum cork_builtin_error {
     CORK_UNKNOWN_ERROR
 };
 
-void
+CORK_API void
 cork_system_error_set(void);
 
-void
+CORK_API void
 cork_unknown_error_set_(const char *location);
 
 #define cork_unknown_error() \

--- a/include/libcork/core/gc.h
+++ b/include/libcork/core/gc.h
@@ -12,6 +12,7 @@
 #define LIBCORK_GC_REFCOUNT_H
 
 
+#include <libcork/core/api.h>
 #include <libcork/core/types.h>
 
 
@@ -38,14 +39,14 @@ struct cork_gc_obj_iface {
 };
 
 
-void
+CORK_API void
 cork_gc_init(void);
 
-void
+CORK_API void
 cork_gc_done(void);
 
 
-void *
+CORK_API void *
 cork_gc_alloc(size_t instance_size, struct cork_gc_obj_iface *iface);
 
 #define cork_gc_new_iface(obj_type, iface) \
@@ -56,10 +57,10 @@ cork_gc_alloc(size_t instance_size, struct cork_gc_obj_iface *iface);
     (cork_gc_new_iface(struct struct_name, &struct_name##__gc))
 
 
-void *
+CORK_API void *
 cork_gc_incref(void *obj);
 
-void
+CORK_API void
 cork_gc_decref(void *obj);
 
 

--- a/include/libcork/core/hash.h
+++ b/include/libcork/core/hash.h
@@ -12,6 +12,7 @@
 #define LIBCORK_CORE_HASH_H
 
 
+#include <libcork/core/api.h>
 #include <libcork/core/attributes.h>
 #include <libcork/core/byte-order.h>
 #include <libcork/core/types.h>

--- a/include/libcork/core/mempool.h
+++ b/include/libcork/core/mempool.h
@@ -13,6 +13,7 @@
 
 
 #include <libcork/config.h>
+#include <libcork/core/api.h>
 #include <libcork/core/attributes.h>
 #include <libcork/core/types.h>
 
@@ -55,7 +56,7 @@ struct cork_mempool_object {
     ((void *) (((struct cork_mempool_object *) (hdr)) + 1))
 
 
-void
+CORK_API void
 cork_mempool_init_size_ex(struct cork_mempool *mp, size_t element_size,
                           size_t block_size);
 
@@ -69,11 +70,11 @@ cork_mempool_init_size_ex(struct cork_mempool *mp, size_t element_size,
 #define cork_mempool_init(mp, type) \
     (cork_mempool_init_size((mp), sizeof(type)))
 
-void
+CORK_API void
 cork_mempool_done(struct cork_mempool *mp);
 
 
-void
+CORK_API void
 cork_mempool_new_block(struct cork_mempool *mp);
 
 
@@ -97,7 +98,7 @@ cork_mempool_new(struct cork_mempool *mp)
 }
 
 
-void
+CORK_API void
 cork_mempool_free(struct cork_mempool *mp, void *ptr);
 
 

--- a/include/libcork/core/net-addresses.h
+++ b/include/libcork/core/net-addresses.h
@@ -14,6 +14,7 @@
 
 #include <string.h>
 
+#include <libcork/core/api.h>
 #include <libcork/core/error.h>
 #include <libcork/core/types.h>
 
@@ -77,16 +78,16 @@ struct cork_ip {
 #define cork_ipv4_equal(a1, a2) \
     ((a1)->_.u32 == (a2)->_.u32)
 
-int
+CORK_API int
 cork_ipv4_init(struct cork_ipv4 *addr, const char *str);
 
-bool
+CORK_API bool
 cork_ipv4_equal_(const struct cork_ipv4 *addr1, const struct cork_ipv4 *addr2);
 
-void
+CORK_API void
 cork_ipv4_to_raw_string(const struct cork_ipv4 *addr, char *dest);
 
-bool
+CORK_API bool
 cork_ipv4_is_valid_network(const struct cork_ipv4 *addr,
                            unsigned int cidr_prefix);
 
@@ -101,16 +102,16 @@ cork_ipv4_is_valid_network(const struct cork_ipv4 *addr,
     ((a1)->_.u64[0] == (a2)->_.u64[0] && \
      (a1)->_.u64[1] == (a2)->_.u64[1])
 
-int
+CORK_API int
 cork_ipv6_init(struct cork_ipv6 *addr, const char *str);
 
-bool
+CORK_API bool
 cork_ipv6_equal_(const struct cork_ipv6 *addr1, const struct cork_ipv6 *addr2);
 
-void
+CORK_API void
 cork_ipv6_to_raw_string(const struct cork_ipv6 *addr, char *dest);
 
-bool
+CORK_API bool
 cork_ipv6_is_valid_network(const struct cork_ipv6 *addr,
                            unsigned int cidr_prefix);
 
@@ -137,23 +138,23 @@ cork_ipv6_is_valid_network(const struct cork_ipv6 *addr,
     } while (0)
 
 /* src must be well-formed: 4 bytes, big-endian */
-void
+CORK_API void
 cork_ip_from_ipv4_(struct cork_ip *addr, const void *src);
 
 /* src must be well-formed: 16 bytes, big-endian */
-void
+CORK_API void
 cork_ip_from_ipv6_(struct cork_ip *addr, const void *src);
 
-int
+CORK_API int
 cork_ip_init(struct cork_ip *addr, const char *str);
 
-bool
+CORK_API bool
 cork_ip_equal_(const struct cork_ip *addr1, const struct cork_ip *addr2);
 
-void
+CORK_API void
 cork_ip_to_raw_string(const struct cork_ip *addr, char *dest);
 
-bool
+CORK_API bool
 cork_ip_is_valid_network(const struct cork_ip *addr, unsigned int cidr_prefix);
 
 

--- a/include/libcork/core/timestamp.h
+++ b/include/libcork/core/timestamp.h
@@ -12,6 +12,7 @@
 #define LIBCORK_CORE_TIMESTAMP_H
 
 
+#include <libcork/core/api.h>
 #include <libcork/core/error.h>
 #include <libcork/core/types.h>
 
@@ -49,7 +50,7 @@ typedef uint64_t  cork_timestamp;
     } while (0)
 
 
-void
+CORK_API void
 cork_timestamp_init_now(cork_timestamp *ts);
 
 
@@ -62,11 +63,11 @@ cork_timestamp_init_now(cork_timestamp *ts);
 #define cork_timestamp_nsec(ts)  cork_timestamp_gsec_to_units(ts, 1000000000)
 
 
-bool
+CORK_API bool
 cork_timestamp_format_utc(const cork_timestamp ts, const char *format,
                           char *buf, size_t size);
 
-bool
+CORK_API bool
 cork_timestamp_format_local(const cork_timestamp ts, const char *format,
                             char *buf, size_t size);
 

--- a/include/libcork/ds/array.h
+++ b/include/libcork/ds/array.h
@@ -12,6 +12,7 @@
 #define LIBCORK_DS_ARRAY_H
 
 
+#include <libcork/core/api.h>
 #include <libcork/core/types.h>
 
 
@@ -54,14 +55,14 @@
     (cork_array_ensure_size_ \
      ((void *) (arr), (count), cork_array_element_size(arr)))
 
-void
+CORK_API void
 cork_array_ensure_size_(void *array, size_t desired_count, size_t element_size);
 
 #define cork_array_append(arr, element) \
     (cork_array_ensure_size((arr), (arr)->size+1), \
      ((arr)->items[(arr)->size++] = (element), 0))
 
-void *
+CORK_API void *
 cork_array_append_get_(void *array, size_t element_size);
 
 #define cork_array_append_get(arr) \

--- a/include/libcork/ds/buffer.h
+++ b/include/libcork/ds/buffer.h
@@ -14,6 +14,7 @@
 
 #include <stdarg.h>
 
+#include <libcork/core/api.h>
 #include <libcork/core/attributes.h>
 #include <libcork/core/types.h>
 
@@ -28,34 +29,34 @@ struct cork_buffer {
 };
 
 
-void
+CORK_API void
 cork_buffer_init(struct cork_buffer *buffer);
 
 #define CORK_BUFFER_INIT()  { NULL, 0, 0 }
 
-struct cork_buffer *
+CORK_API struct cork_buffer *
 cork_buffer_new(void);
 
-void
+CORK_API void
 cork_buffer_done(struct cork_buffer *buffer);
 
-void
+CORK_API void
 cork_buffer_free(struct cork_buffer *buffer);
 
 
-bool
+CORK_API bool
 cork_buffer_equal(const struct cork_buffer *buffer1,
                   const struct cork_buffer *buffer2);
 
 
-void
+CORK_API void
 cork_buffer_ensure_size(struct cork_buffer *buffer, size_t desired_size);
 
 
-void
+CORK_API void
 cork_buffer_clear(struct cork_buffer *buffer);
 
-void
+CORK_API void
 cork_buffer_truncate(struct cork_buffer *buffer, size_t length);
 
 #define cork_buffer_byte(buffer, i)  (((const uint8_t *) (buffer)->buf)[(i)])
@@ -69,34 +70,34 @@ cork_buffer_truncate(struct cork_buffer *buffer, size_t length);
 #define cork_buffer_copy(dest, src) \
     (cork_buffer_set((dest), (src)->buf, (src)->size))
 
-void
+CORK_API void
 cork_buffer_set(struct cork_buffer *buffer, const void *src, size_t length);
 
-void
+CORK_API void
 cork_buffer_append(struct cork_buffer *buffer, const void *src, size_t length);
 
 
-void
+CORK_API void
 cork_buffer_set_string(struct cork_buffer *buffer, const char *str);
 
-void
+CORK_API void
 cork_buffer_append_string(struct cork_buffer *buffer, const char *str);
 
 
-void
+CORK_API void
 cork_buffer_printf(struct cork_buffer *buffer, const char *format, ...)
     CORK_ATTR_PRINTF(2,3);
 
-void
+CORK_API void
 cork_buffer_append_printf(struct cork_buffer *buffer, const char *format, ...)
     CORK_ATTR_PRINTF(2,3);
 
-void
+CORK_API void
 cork_buffer_vprintf(struct cork_buffer *buffer, const char *format,
                     va_list args)
     CORK_ATTR_PRINTF(2,0);
 
-void
+CORK_API void
 cork_buffer_append_vprintf(struct cork_buffer *buffer, const char *format,
                            va_list args)
     CORK_ATTR_PRINTF(2,0);
@@ -109,10 +110,10 @@ cork_buffer_append_vprintf(struct cork_buffer *buffer, const char *format,
 #include <libcork/ds/managed-buffer.h>
 #include <libcork/ds/slice.h>
 
-struct cork_managed_buffer *
+CORK_API struct cork_managed_buffer *
 cork_buffer_to_managed_buffer(struct cork_buffer *buffer);
 
-int
+CORK_API int
 cork_buffer_to_slice(struct cork_buffer *buffer, struct cork_slice *slice);
 
 
@@ -122,7 +123,7 @@ cork_buffer_to_slice(struct cork_buffer *buffer, struct cork_slice *slice);
 
 #include <libcork/ds/stream.h>
 
-struct cork_stream_consumer *
+CORK_API struct cork_stream_consumer *
 cork_buffer_to_stream_consumer(struct cork_buffer *buffer);
 
 

--- a/include/libcork/ds/dllist.h
+++ b/include/libcork/ds/dllist.h
@@ -11,7 +11,7 @@
 #ifndef LIBCORK_DS_DLLIST_H
 #define LIBCORK_DS_DLLIST_H
 
-
+#include <libcork/core/api.h>
 #include <libcork/core/types.h>
 
 
@@ -29,19 +29,19 @@ struct cork_dllist {
 };
 
 
-void
+CORK_API void
 cork_dllist_init(struct cork_dllist *list);
 
 
 typedef void
 (*cork_dllist_map_func)(struct cork_dllist_item *element, void *user_data);
 
-void
+CORK_API void
 cork_dllist_map(struct cork_dllist *list,
                 cork_dllist_map_func func, void *user_data);
 
 
-size_t
+CORK_API size_t
 cork_dllist_size(const struct cork_dllist *list);
 
 

--- a/include/libcork/ds/hash-table.h
+++ b/include/libcork/ds/hash-table.h
@@ -11,7 +11,7 @@
 #ifndef LIBCORK_DS_HASH_TABLE_H
 #define LIBCORK_DS_HASH_TABLE_H
 
-
+#include <libcork/core/api.h>
 #include <libcork/core/hash.h>
 #include <libcork/core/mempool.h>
 #include <libcork/core/types.h>
@@ -56,52 +56,52 @@ struct cork_hash_table {
 };
 
 
-void
+CORK_API void
 cork_hash_table_init(struct cork_hash_table *table,
                      size_t initial_size,
                      cork_hash_table_hasher hasher,
                      cork_hash_table_comparator comparator);
 
-struct cork_hash_table *
+CORK_API struct cork_hash_table *
 cork_hash_table_new(size_t initial_size,
                     cork_hash_table_hasher hasher,
                     cork_hash_table_comparator comparator);
 
-void
+CORK_API void
 cork_hash_table_done(struct cork_hash_table *table);
 
-void
+CORK_API void
 cork_hash_table_free(struct cork_hash_table *table);
 
 
-void
+CORK_API void
 cork_hash_table_clear(struct cork_hash_table *table);
 
 
-void
+CORK_API void
 cork_hash_table_ensure_size(struct cork_hash_table *table,
                             size_t desired_count);
 
 #define cork_hash_table_size(table) ((table)->entry_count)
 
 
-void *
+CORK_API void *
 cork_hash_table_get(const struct cork_hash_table *table, const void *key);
 
-struct cork_hash_table_entry *
+CORK_API struct cork_hash_table_entry *
 cork_hash_table_get_entry(const struct cork_hash_table *table,
                           const void *key);
 
-struct cork_hash_table_entry *
+CORK_API struct cork_hash_table_entry *
 cork_hash_table_get_or_create(struct cork_hash_table *table,
                               void *key, bool *is_new);
 
-void
+CORK_API void
 cork_hash_table_put(struct cork_hash_table *table,
                     void *key, void *value, bool *is_new,
                     void **old_key, void **old_value);
 
-bool
+CORK_API bool
 cork_hash_table_delete(struct cork_hash_table *table, const void *key,
                        void **deleted_key, void **deleted_value);
 
@@ -120,7 +120,7 @@ typedef enum cork_hash_table_map_result
 (*cork_hash_table_mapper)(struct cork_hash_table_entry *entry,
                           void *user_data);
 
-void
+CORK_API void
 cork_hash_table_map(struct cork_hash_table *table,
                     cork_hash_table_mapper mapper, void *user_data);
 
@@ -133,11 +133,11 @@ struct cork_hash_table_iterator {
     struct cork_dllist_item  *curr;
 };
 
-void
+CORK_API void
 cork_hash_table_iterator_init(struct cork_hash_table *table,
                               struct cork_hash_table_iterator *iterator);
 
-struct cork_hash_table_entry *
+CORK_API struct cork_hash_table_entry *
 cork_hash_table_iterator_next(struct cork_hash_table_iterator *iterator);
 
 
@@ -145,17 +145,17 @@ cork_hash_table_iterator_next(struct cork_hash_table_iterator *iterator);
  * Built-in key types
  */
 
-void
+CORK_API void
 cork_string_hash_table_init(struct cork_hash_table *table, size_t initial_size);
 
-struct cork_hash_table *
+CORK_API struct cork_hash_table *
 cork_string_hash_table_new(size_t initial_size);
 
-void
+CORK_API void
 cork_pointer_hash_table_init(struct cork_hash_table *table,
                               size_t initial_size);
 
-struct cork_hash_table *
+CORK_API struct cork_hash_table *
 cork_pointer_hash_table_new(size_t initial_size);
 
 

--- a/include/libcork/ds/managed-buffer.h
+++ b/include/libcork/ds/managed-buffer.h
@@ -11,7 +11,7 @@
 #ifndef LIBCORK_DS_MANAGED_BUFFER_H
 #define LIBCORK_DS_MANAGED_BUFFER_H
 
-
+#include <libcork/core/api.h>
 #include <libcork/core/types.h>
 #include <libcork/ds/slice.h>
 
@@ -43,31 +43,31 @@ struct cork_managed_buffer {
 };
 
 
-struct cork_managed_buffer *
+CORK_API struct cork_managed_buffer *
 cork_managed_buffer_new_copy(const void *buf, size_t size);
 
 
 typedef void
 (*cork_managed_buffer_freer)(void *buf, size_t size);
 
-struct cork_managed_buffer *
+CORK_API struct cork_managed_buffer *
 cork_managed_buffer_new(const void *buf, size_t size,
                         cork_managed_buffer_freer free);
 
 
-struct cork_managed_buffer *
+CORK_API struct cork_managed_buffer *
 cork_managed_buffer_ref(struct cork_managed_buffer *buf);
 
-void
+CORK_API void
 cork_managed_buffer_unref(struct cork_managed_buffer *buf);
 
 
-int
+CORK_API int
 cork_managed_buffer_slice(struct cork_slice *dest,
                           struct cork_managed_buffer *buffer,
                           size_t offset, size_t length);
 
-int
+CORK_API int
 cork_managed_buffer_slice_offset(struct cork_slice *dest,
                                  struct cork_managed_buffer *buffer,
                                  size_t offset);

--- a/include/libcork/ds/ring-buffer.h
+++ b/include/libcork/ds/ring-buffer.h
@@ -11,7 +11,7 @@
 #ifndef LIBCORK_DS_RING_BUFFER_H
 #define LIBCORK_DS_RING_BUFFER_H
 
-
+#include <libcork/core/api.h>
 #include <libcork/core/types.h>
 
 
@@ -30,10 +30,10 @@ struct cork_ring_buffer {
 };
 
 
-int
+CORK_API int
 cork_ring_buffer_init(struct cork_ring_buffer *buf, size_t size);
 
-void
+CORK_API void
 cork_ring_buffer_done(struct cork_ring_buffer *buf);
 
 
@@ -41,13 +41,13 @@ cork_ring_buffer_done(struct cork_ring_buffer *buf);
 #define cork_ring_buffer_is_full(buf) ((buf)->size == (buf)->allocated_size)
 
 
-int
+CORK_API int
 cork_ring_buffer_add(struct cork_ring_buffer *buf, void *element);
 
-void *
+CORK_API void *
 cork_ring_buffer_pop(struct cork_ring_buffer *buf);
 
-void *
+CORK_API void *
 cork_ring_buffer_peek(struct cork_ring_buffer *buf);
 
 

--- a/include/libcork/ds/slice.h
+++ b/include/libcork/ds/slice.h
@@ -11,7 +11,7 @@
 #ifndef LIBCORK_DS_SLICE_H
 #define LIBCORK_DS_SLICE_H
 
-
+#include <libcork/core/api.h>
 #include <libcork/core/types.h>
 
 
@@ -69,20 +69,20 @@ struct cork_slice {
 };
 
 
-void
+CORK_API void
 cork_slice_clear(struct cork_slice *slice);
 
 #define cork_slice_is_empty(slice)  ((slice)->buf == NULL)
 
 
-int
+CORK_API int
 cork_slice_copy(struct cork_slice *dest, struct cork_slice *slice,
                 size_t offset, size_t length);
 
 #define cork_slice_copy_fast(dest, slice, offset, length) \
     ((slice)->iface->copy((slice), (dest), (offset), (length)))
 
-int
+CORK_API int
 cork_slice_copy_offset(struct cork_slice *dest, struct cork_slice *slice,
                        size_t offset);
 
@@ -91,7 +91,7 @@ cork_slice_copy_offset(struct cork_slice *dest, struct cork_slice *slice,
      ((slice), (dest), (offset), (slice)->size - (offset)))
 
 
-int
+CORK_API int
 cork_slice_slice(struct cork_slice *slice, size_t offset, size_t length);
 
 #define cork_slice_slice_fast(_slice, offset, length) \
@@ -99,7 +99,7 @@ cork_slice_slice(struct cork_slice *slice, size_t offset, size_t length);
      ((_slice)->buf += (offset), (_slice)->size = (length), 0): \
      ((_slice)->iface->slice((_slice), (offset), (length))))
 
-int
+CORK_API int
 cork_slice_slice_offset(struct cork_slice *slice, size_t offset);
 
 #define cork_slice_slice_offset_fast(_slice, offset) \
@@ -109,14 +109,14 @@ cork_slice_slice_offset(struct cork_slice *slice, size_t offset);
       ((_slice), (offset), (_slice)->size - (offset))))
 
 
-void
+CORK_API void
 cork_slice_finish(struct cork_slice *slice);
 
-bool
+CORK_API bool
 cork_slice_equal(const struct cork_slice *slice1,
                  const struct cork_slice *slice2);
 
-void
+CORK_API void
 cork_slice_init_static(struct cork_slice *dest, const void *buf, size_t size);
 
 

--- a/include/libcork/ds/stream.h
+++ b/include/libcork/ds/stream.h
@@ -11,9 +11,9 @@
 #ifndef LIBCORK_DS_STREAM_H
 #define LIBCORK_DS_STREAM_H
 
-
 #include <stdio.h>
 
+#include <libcork/core/api.h>
 #include <libcork/core/types.h>
 
 
@@ -40,24 +40,24 @@ struct cork_stream_consumer {
     ((consumer)->free((consumer)))
 
 
-int
+CORK_API int
 cork_consume_fd(struct cork_stream_consumer *consumer, int fd);
 
-int
+CORK_API int
 cork_consume_file(struct cork_stream_consumer *consumer, FILE *fp);
 
-int
+CORK_API int
 cork_consume_file_from_path(struct cork_stream_consumer *consumer,
                             const char *path, int flags);
 
 
-struct cork_stream_consumer *
+CORK_API struct cork_stream_consumer *
 cork_fd_consumer_new(int fd);
 
-struct cork_stream_consumer *
+CORK_API struct cork_stream_consumer *
 cork_file_consumer_new(FILE *fp);
 
-struct cork_stream_consumer *
+CORK_API struct cork_stream_consumer *
 cork_file_from_path_consumer_new(const char *path, int flags);
 
 

--- a/include/libcork/os/files.h
+++ b/include/libcork/os/files.h
@@ -11,6 +11,7 @@
 #ifndef LIBCORK_CORE_FILES_H
 #define LIBCORK_CORE_FILES_H
 
+#include <libcork/core/api.h>
 #include <libcork/core/types.h>
 
 
@@ -40,7 +41,7 @@ struct cork_dir_walker {
     ((w)->leave_directory((w), (fp), (rp), (bn)))
 
 
-int
+CORK_API int
 cork_walk_directory(const char *path, struct cork_dir_walker *walker);
 
 

--- a/include/libcork/os/subprocess.h
+++ b/include/libcork/os/subprocess.h
@@ -11,6 +11,7 @@
 #ifndef LIBCORK_OS_PROCESS_H
 #define LIBCORK_OS_PROCESS_H
 
+#include <libcork/core/api.h>
 #include <libcork/core/types.h>
 #include <libcork/ds/stream.h>
 #include <libcork/threads/basics.h>
@@ -23,17 +24,17 @@
 struct cork_subprocess;
 
 /* Takes control of body */
-struct cork_subprocess *
+CORK_API struct cork_subprocess *
 cork_subprocess_new(struct cork_thread_body *body,
                     struct cork_stream_consumer *stdout_consumer,
                     struct cork_stream_consumer *stderr_consumer);
 
-struct cork_subprocess *
+CORK_API struct cork_subprocess *
 cork_subprocess_new_exec(const char *program, char * const *params,
                          struct cork_stream_consumer *stdout_consumer,
                          struct cork_stream_consumer *stderr_consumer);
 
-void
+CORK_API void
 cork_subprocess_free(struct cork_subprocess *sub);
 
 
@@ -43,30 +44,30 @@ cork_subprocess_free(struct cork_subprocess *sub);
 
 struct cork_subprocess_group;
 
-struct cork_subprocess_group *
+CORK_API struct cork_subprocess_group *
 cork_subprocess_group_new(void);
 
-void
+CORK_API void
 cork_subprocess_group_free(struct cork_subprocess_group *group);
 
 /* Takes control of sub */
-void
+CORK_API void
 cork_subprocess_group_add(struct cork_subprocess_group *group,
                           struct cork_subprocess *sub);
 
-int
+CORK_API int
 cork_subprocess_group_start(struct cork_subprocess_group *group);
 
-bool
+CORK_API bool
 cork_subprocess_group_is_finished(struct cork_subprocess_group *group);
 
-int
+CORK_API int
 cork_subprocess_group_abort(struct cork_subprocess_group *group);
 
-int
+CORK_API int
 cork_subprocess_group_drain(struct cork_subprocess_group *group);
 
-int
+CORK_API int
 cork_subprocess_group_wait(struct cork_subprocess_group *group);
 
 

--- a/include/libcork/threads/basics.h
+++ b/include/libcork/threads/basics.h
@@ -13,6 +13,7 @@
 
 #include <assert.h>
 
+#include <libcork/core/api.h>
 #include <libcork/core/attributes.h>
 #include <libcork/threads/atomics.h>
 
@@ -25,7 +26,7 @@ typedef unsigned int  cork_thread_id;
 
 #define CORK_THREAD_NONE  ((cork_thread_id) 0)
 
-cork_thread_id
+CORK_API cork_thread_id
 cork_thread_get_id(void);
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(libcork SHARED ${LIBCORK_SRC})
 target_link_libraries(libcork ${CMAKE_THREAD_LIBS_INIT})
 set_target_properties(libcork PROPERTIES
     OUTPUT_NAME cork
+    COMPILE_DEFINITIONS CORK_API=CORK_EXPORT
     VERSION 11.0.2
     SOVERSION 11)
 
@@ -73,7 +74,9 @@ set_target_properties(libcork PROPERTIES
 add_library(embedded_libcork STATIC ${LIBCORK_SRC})
 target_link_libraries(embedded_libcork ${CMAKE_THREAD_LIBS_INIT})
 set_target_properties(embedded_libcork PROPERTIES
-    OUTPUT_NAME cork-embedded)
+    OUTPUT_NAME cork-embedded
+    COMPILE_DEFINITIONS CORK_API=CORK_LOCAL
+)
 
 #-----------------------------------------------------------------------
 # Utility commands

--- a/src/libcork/core/hash.c
+++ b/src/libcork/core/hash.c
@@ -8,7 +8,7 @@
  * ----------------------------------------------------------------------
  */
 
-#define CORK_HASH_ATTRIBUTES  /* not static in here! */
+#define CORK_HASH_ATTRIBUTES  CORK_API
 
 #include "libcork/core/hash.h"
 #include "libcork/core/types.h"


### PR DESCRIPTION
We need the ability to explicitly mark which functions are part of a library's public API, and which are internal to the library.  There's a good description of why this is useful on the [GCC wiki](http://gcc.gnu.org/wiki/Visibility).  We'll also need something like this for our eventual Windows port, since you're required to mark the functions that are exported by a DLL.
