### PR TITLE
Fix expected hashes on big-endian 32-bit systems

### DIFF
--- a/tests/test-core.c
+++ b/tests/test-core.c
@@ -267,6 +267,8 @@ END_TEST
 
 START_TEST(test_hash)
 {
+    DESCRIBE_TEST;
+
     static const char  BUF[] = "test";
     static size_t  LEN = sizeof(BUF);
     static const char  LONG_BUF[] =
@@ -276,6 +278,8 @@ START_TEST(test_hash)
     static size_t  LONG_LEN = sizeof(LONG_BUF);
     uint32_t  val32 = 1234;
     uint64_t  val64 = 1234;
+    uint32_t  stable_val32 = CORK_UINT32_HOST_TO_LITTLE(1234);
+    uint64_t  stable_val64 = CORK_UINT64_HOST_TO_LITTLE(1234);
 
     /* without the NUL terminator */
     test_stable_hash_buf(BUF, LEN-1, 0xba6bd213);
@@ -286,7 +290,7 @@ START_TEST(test_hash)
       /*    big 64 */ 0x74bde19d);
     test_big_hash_buf(BUF, LEN-1,
       /* little 32 */ 0x550c7d686f02ef30, 0x550c7d68550c7d68,
-      /*    big 32 */ 0x550c7d686f02ef30, 0x550c7d68550c7d68,
+      /*    big 32 */ 0x6f02ef30550c7d68, 0x550c7d68550c7d68,
       /* little 64 */ 0xac7d28cc74bde19d, 0x9a128231f9bd4d82,
       /*    big 64 */ 0xac7d28cc74bde19d, 0x9a128231f9bd4d82);
 
@@ -299,7 +303,7 @@ START_TEST(test_hash)
       /*    big 64 */ 0x4d18f852);
     test_big_hash_buf(BUF, LEN,
       /* little 32 */ 0x29ab177c98c2b52b, 0x29ab177c29ab177c,
-      /*    big 32 */ 0x29ab177c98c2b52b, 0x29ab177c29ab177c,
+      /*    big 32 */ 0x98c2b52b29ab177c, 0x29ab177c29ab177c,
       /* little 64 */ 0xc3812fdf4d18f852, 0xc81a9057aa737aec,
       /*    big 64 */ 0xc3812fdf4d18f852, 0xc81a9057aa737aec);
 
@@ -312,7 +316,7 @@ START_TEST(test_hash)
       /*    big 64 */ 0x03578c96);
     test_big_hash_buf(LONG_BUF, LONG_LEN-1,
       /* little 32 */ 0x4fb7793c4240d513, 0x799f335aee7e281c,
-      /*    big 32 */ 0x029c92a4ab564a5e, 0x1093400f0bd80c74,
+      /*    big 32 */ 0xab564a5e029c92a4, 0x0bd80c741093400f,
       /* little 64 */ 0xcbdc20928fa72e9c, 0x48de52d2c680420e,
       /*    big 64 */ 0x5935f90a03578c96, 0x163e514fff9c30a8);
 
@@ -325,21 +329,21 @@ START_TEST(test_hash)
       /*    big 64 */ 0x8c919559);
     test_big_hash_buf(LONG_BUF, LONG_LEN,
       /* little 32 */ 0xc261514663bcdcd0, 0xece3cab68e7fd7aa,
-      /*    big 32 */ 0xa3fc07fd250b47cd, 0x06aafbd0840c4bb6,
+      /*    big 32 */ 0x250b47cda3fc07fd, 0x840c4bb606aafbd0,
       /* little 64 */ 0xe89ec0054becb434, 0x826391b83f0b4d3e,
       /*    big 64 */ 0xf00a12ab8c919559, 0x684ecf4973c66eac);
 
-    test_stable_hash_var(val32, 0x6bb65380);
+    test_stable_hash_var(stable_val32, 0x6bb65380);
     test_hash_var(val32,
       /* little 32 */ 0x6bb65380,
-      /*    big 32 */ 0xf9cbc101,
+      /*    big 32 */ 0x6bb65380,
       /* little 64 */ 0x7e1b3998,
       /*    big 64 */ 0x7e1b3998);
 
-    test_stable_hash_var(val64, 0x4d5c4063);
+    test_stable_hash_var(stable_val64, 0x4d5c4063);
     test_hash_var(val64,
       /* little 32 */ 0x4d5c4063,
-      /*    big 32 */ 0x5f426cab,
+      /*    big 32 */ 0xbaeee6e9,
       /* little 64 */ 0x267305fb,
       /*    big 64 */ 0x267305fb);
 }


### PR DESCRIPTION
The expected values in our hash value test cases were incorrect on 32-bit, big-endian systems (such as PowerPC).
