### PR TITLE
Custom subprocess environment lists

### DIFF
--- a/include/libcork/core/allocator.h
+++ b/include/libcork/core/allocator.h
@@ -42,6 +42,9 @@ cork_xrealloc(void *ptr, size_t new_size) CORK_ATTR_MALLOC;
 CORK_API const char *
 cork_xstrdup(const char *str);
 
+CORK_API const char *
+cork_xstrndup(const char *str, size_t size);
+
 CORK_API void
 cork_strfree(const char *str);
 
@@ -60,6 +63,9 @@ cork_strfree(const char *str);
 #define cork_strdup(str) \
     ((const char *) cork_abort_if_null \
      ((void *) cork_xstrdup((str)), "strdup failed"))
+#define cork_strndup(str, size) \
+    ((const char *) cork_abort_if_null \
+     ((void *) cork_xstrndup((str), (size)), "strndup failed"))
 
 
 #endif /* LIBCORK_CORE_ALLOCATOR_H */

--- a/include/libcork/os/subprocess.h
+++ b/include/libcork/os/subprocess.h
@@ -11,10 +11,48 @@
 #ifndef LIBCORK_OS_SUBPROCESS_H
 #define LIBCORK_OS_SUBPROCESS_H
 
+#include <stdarg.h>
+
 #include <libcork/core/api.h>
 #include <libcork/core/types.h>
 #include <libcork/ds/stream.h>
 #include <libcork/threads/basics.h>
+
+
+/*-----------------------------------------------------------------------
+ * Environments
+ */
+
+struct cork_env;
+
+CORK_API struct cork_env *
+cork_env_new(void);
+
+CORK_API struct cork_env *
+cork_env_clone_current(void);
+
+CORK_API void
+cork_env_free(struct cork_env *env);
+
+CORK_API void
+cork_env_add(struct cork_env *env, const char *name, const char *value);
+
+CORK_API void
+cork_env_add_printf(struct cork_env *env, const char *name,
+                    const char *format, ...)
+    CORK_ATTR_PRINTF(3,4);
+
+CORK_API void
+cork_env_add_vprintf(struct cork_env *env, const char *name,
+                     const char *format, va_list args)
+    CORK_ATTR_PRINTF(3,0);
+
+CORK_API void
+cork_env_remove(struct cork_env *env, const char *name);
+
+
+CORK_API void
+cork_env_replace_current(struct cork_env *env);
 
 
 /*-----------------------------------------------------------------------
@@ -23,15 +61,19 @@
 
 struct cork_subprocess;
 
-/* Takes control of body */
+/* If env is NULL, we use the environment variables of the calling process. */
+
+/* Takes control of body and env */
 CORK_API struct cork_subprocess *
-cork_subprocess_new(struct cork_thread_body *body,
+cork_subprocess_new(struct cork_thread_body *body, struct cork_env *env,
                     struct cork_stream_consumer *stdout_consumer,
                     struct cork_stream_consumer *stderr_consumer,
                     int *exit_code);
 
+/* Takes control of env */
 CORK_API struct cork_subprocess *
 cork_subprocess_new_exec(const char *program, char * const *params,
+                         struct cork_env *env,
                          struct cork_stream_consumer *stdout_consumer,
                          struct cork_stream_consumer *stderr_consumer,
                          int *exit_code);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ set(LIBCORK_SRC
     libcork/ds/ring-buffer.c
     libcork/ds/slice.c
     libcork/posix/directory-walker.c
+    libcork/posix/env.c
     libcork/posix/process.c
     libcork/posix/subprocess.c
     libcork/pthreads/thread.c

--- a/src/cork-test/cork-test.c
+++ b/src/cork-test/cork-test.c
@@ -165,11 +165,13 @@ static struct cork_command  c2 =
 static void
 sub_run(int argc, char **argv)
 {
+    struct cork_env  *env;
     struct cork_subprocess_group  *group;
     struct cork_subprocess  *sub;
+    rp_check_exit(env = cork_env_clone_current());
     rp_check_exit(group = cork_subprocess_group_new());
     rp_check_exit(sub = cork_subprocess_new_exec
-                  (argv[0], argv, NULL, NULL, NULL));
+                  (argv[0], argv, env, NULL, NULL, NULL));
     cork_subprocess_group_add(group, sub);
     ri_check_exit(cork_subprocess_group_start(group));
     ri_check_exit(cork_subprocess_group_wait(group));

--- a/src/libcork/core/allocator.c
+++ b/src/libcork/core/allocator.c
@@ -38,10 +38,9 @@ cork_xrealloc(void *ptr, size_t new_size)
  * Allocating strings
  */
 
-const char *
-cork_xstrdup(const char *str)
+static inline const char *
+strndup_internal(const char *str, size_t len)
 {
-    size_t  len = strlen(str);
     size_t  allocated_size = len + sizeof(size_t) + 1;
     size_t  *new_str = malloc(allocated_size);
     if (new_str == NULL) {
@@ -52,6 +51,18 @@ cork_xstrdup(const char *str)
     char  *dest = (char *) (void *) (new_str + 1);
     strncpy(dest, str, len + 1);
     return dest;
+}
+
+const char *
+cork_xstrndup(const char *str, size_t len)
+{
+    return strndup_internal(str, len);
+}
+
+const char *
+cork_xstrdup(const char *str)
+{
+    return strndup_internal(str, strlen(str));
 }
 
 

--- a/src/libcork/posix/env.c
+++ b/src/libcork/posix/env.c
@@ -1,0 +1,165 @@
+/* -*- coding: utf-8 -*-
+ * ----------------------------------------------------------------------
+ * Copyright © 2013, RedJack, LLC.
+ * All rights reserved.
+ *
+ * Please see the COPYING file in this distribution for license
+ * details.
+ * ----------------------------------------------------------------------
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "libcork/core.h"
+#include "libcork/ds.h"
+#include "libcork/os/subprocess.h"
+#include "libcork/helpers/errors.h"
+
+extern const char  **environ;
+
+
+struct cork_env_var {
+    const char  *name;
+    const char  *value;
+};
+
+static struct cork_env_var *
+cork_env_var_new(const char *name, const char *value)
+{
+    struct cork_env_var  *var = cork_new(struct cork_env_var);
+    var->name = cork_strdup(name);
+    var->value = cork_strdup(value);
+    return var;
+}
+
+static void
+cork_env_var_free(struct cork_env_var *var)
+{
+    cork_strfree(var->name);
+    cork_strfree(var->value);
+    free(var);
+}
+
+
+struct cork_env {
+    struct cork_hash_table  variables;
+    struct cork_buffer  buffer;
+};
+
+struct cork_env *
+cork_env_new(void)
+{
+    struct cork_env  *env = cork_new(struct cork_env);
+    cork_string_hash_table_init(&env->variables, 0);
+    cork_buffer_init(&env->buffer);
+    return env;
+}
+
+static void
+cork_env_add_internal(struct cork_env *env, const char *name, const char *value)
+{
+    struct cork_env_var  *var = cork_env_var_new(name, value);
+    void  *old_var;
+
+    cork_hash_table_put
+        (&env->variables, (void *) var->name, var, NULL, NULL, &old_var);
+
+    if (old_var != NULL) {
+        cork_env_var_free(old_var);
+    }
+}
+
+struct cork_env *
+cork_env_clone_current(void)
+{
+    const char  **curr;
+    struct cork_env  *env = cork_env_new();
+
+    for (curr = environ; *curr != NULL; curr++) {
+        const char  *entry = *curr;
+        const char  *equal;
+
+        equal = strchr(entry, '=');
+        if (CORK_UNLIKELY(equal == NULL)) {
+            /* This environment entry is malformed; skip it. */
+            continue;
+        }
+
+        /* Make a copy of the name so that it's NUL-terminated rather than
+         * equal-terminated. */
+        cork_buffer_set(&env->buffer, entry, equal - entry);
+        cork_env_add_internal(env, env->buffer.buf, equal + 1);
+    }
+
+    return env;
+}
+
+
+static enum cork_hash_table_map_result
+cork_env_free_vars(struct cork_hash_table_entry *entry, void *user_data)
+{
+    struct cork_env_var  *var = entry->value;
+    cork_env_var_free(var);
+    return CORK_HASH_TABLE_MAP_DELETE;
+}
+
+void
+cork_env_free(struct cork_env *env)
+{
+    cork_hash_table_map(&env->variables, cork_env_free_vars, NULL);
+    cork_hash_table_done(&env->variables);
+    cork_buffer_done(&env->buffer);
+    free(env);
+}
+
+void
+cork_env_add(struct cork_env *env, const char *name, const char *value)
+{
+    cork_env_add_internal(env, name, value);
+}
+
+void
+cork_env_add_vprintf(struct cork_env *env, const char *name,
+                     const char *format, va_list args)
+{
+    cork_buffer_vprintf(&env->buffer, format, args);
+    cork_env_add_internal(env, name, env->buffer.buf);
+}
+
+void
+cork_env_add_printf(struct cork_env *env, const char *name,
+                    const char *format, ...)
+{
+    va_list  args;
+    va_start(args, format);
+    cork_env_add_vprintf(env, name, format, args);
+    va_end(args);
+}
+
+void
+cork_env_remove(struct cork_env *env, const char *name)
+{
+    void  *old_var;
+    cork_hash_table_delete(&env->variables, (void *) name, NULL, &old_var);
+    if (old_var != NULL) {
+        cork_env_var_free(old_var);
+    }
+}
+
+
+static enum cork_hash_table_map_result
+cork_env_set_vars(struct cork_hash_table_entry *entry, void *user_data)
+{
+    struct cork_env_var  *var = entry->value;
+    setenv(var->name, var->value, false);
+    return CORK_HASH_TABLE_MAP_CONTINUE;
+}
+
+void
+cork_env_replace_current(struct cork_env *env)
+{
+    clearenv();
+    cork_hash_table_map(&env->variables, cork_env_set_vars, NULL);
+}

--- a/tests/cork-test/run-sub-03.t
+++ b/tests/cork-test/run-sub-03.t
@@ -1,0 +1,2 @@
+  $ CORK_TEST_VAR="Hello world" cork-test sub sh -c 'echo $CORK_TEST_VAR'
+  Hello world


### PR DESCRIPTION
We need a way to pass in a custom list of environment variables to subprocesses.  Right now subprocesses always inherit the environment of the calling process (which should still be a possibility).
