### PR TITLE
clearenv replacement on Mac OS X and BSDs

### DIFF
--- a/src/libcork/posix/env.c
+++ b/src/libcork/posix/env.c
@@ -157,6 +157,40 @@ cork_env_set_vars(struct cork_hash_table_entry *entry, void *user_data)
     return CORK_HASH_TABLE_MAP_CONTINUE;
 }
 
+#if defined(__APPLE__)
+/* Apple doesn't provide clearenv(), and it also doesn't let us access the
+ * "environ" variable from a shared library.  There's a workaround function to
+ * grab the environ pointer described at [1].
+ *
+ * [1] http://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man7/environ.7.html
+ */
+
+#include <crt_externs.h>
+
+static void
+clearenv(void)
+{
+    char  ***ns_environ = _NSGetEnviron();
+    **ns_environ = NULL;
+}
+
+#elif defined(__FreeBSD__) || defined (__NetBSD__) || defined(__OpenBSD__)
+/* A handful of other platforms [1] don't provide clearenv(), but do allow us to
+ * access the environ pointer directly.
+ *
+ * [1] http://www.gnu.org/software/gnulib/manual/html_node/clearenv.html
+ */
+static void
+clearenv(void)
+{
+    extern char  **environ;
+    *environ = NULL;
+}
+
+#else
+/* Otherwise assume that we have clearenv available. */
+#endif
+
 void
 cork_env_replace_current(struct cork_env *env)
 {


### PR DESCRIPTION
Mac OS X, FreeBSD, OpenBSD, and NetBSD don't provide the `clearenv(3)` function, which we were using to clear out the current environment before replacing it with the contents of a `cork_env` instance.  This patch adds replacement implementations on these platforms.  On the BSDs, the replacement is simple; we just assign an empty array into the `extern` variable.  On Mac OS X, however, we don't have access to `environ` in a shared library, and must use a [helper function](http://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man7/environ.7.html) to get the pointer to the environment array.

Note that there are several other platforms that also don't provide `clearenv(3)` (see a [full list](http://www.gnu.org/software/gnulib/manual/html_node/clearenv.html)).  At some point, we'll want to expand our preprocessor checks to provide the replacement implementation on those platforms, too.  But I don't have instances of those platforms to test on, so I'm leaving them out for now.
