### PR TITLE
Libcork doesn't build on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,8 @@ execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/version.sh
     OUTPUT_VARIABLE VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 if(VERSION_RESULT)
-    message(FATAL_ERROR "Cannot determine version number")
+    message(FATAL_ERROR
+            "Cannot determine version number: " ${VERSION_RESULT})
 endif(VERSION_RESULT)
 # This causes an annoying extra prompt in ccmake.
 # message("Current version: " ${VERSION})

--- a/include/libcork/config/bsd.h
+++ b/include/libcork/config/bsd.h
@@ -1,0 +1,34 @@
+/* -*- coding: utf-8 -*-
+ * ----------------------------------------------------------------------
+ * Copyright © 2013, RedJack, LLC.
+ * All rights reserved.
+ *
+ * Please see the COPYING file in this distribution for license
+ * details.
+ * ----------------------------------------------------------------------
+ */
+
+#ifndef LIBCORK_CONFIG_BSD_H
+#define LIBCORK_CONFIG_BSD_H
+
+/*-----------------------------------------------------------------------
+ * Endianness
+ */
+
+#include <sys/endian.h>
+
+#if BYTE_ORDER == BIG_ENDIAN
+#define CORK_CONFIG_IS_BIG_ENDIAN      1
+#define CORK_CONFIG_IS_LITTLE_ENDIAN   0
+#elif BYTE_ORDER == LITTLE_ENDIAN
+#define CORK_CONFIG_IS_BIG_ENDIAN      0
+#define CORK_CONFIG_IS_LITTLE_ENDIAN   1
+#else
+#error "Cannot determine system endianness"
+#endif
+
+#define CORK_HAVE_REALLOCF  1
+#define CORK_HAVE_PTHREADS  1
+
+
+#endif /* LIBCORK_CONFIG_BSD_H */

--- a/include/libcork/config/config.h
+++ b/include/libcork/config/config.h
@@ -1,6 +1,6 @@
 /* -*- coding: utf-8 -*-
  * ----------------------------------------------------------------------
- * Copyright © 2011-2012, RedJack, LLC.
+ * Copyright © 2011-2013, RedJack, LLC.
  * All rights reserved.
  *
  * Please see the COPYING file in this distribution for license
@@ -34,6 +34,11 @@
 
 
 /**** PLATFORMS ****/
+#if (defined(__unix__) || defined(unix)) && !defined(USG)
+/* We need this to test for BSD, but it's a good idea to have for
+ * any brand of Unix.*/
+#include <sys/param.h>
+#endif
 
 #if defined(__linux)
 /* Do some Linux-specific autodetection. */
@@ -42,6 +47,10 @@
 #elif defined(__APPLE__) && defined(__MACH__)
 /* Do some Mac OS X-specific autodetection. */
 #include <libcork/config/macosx.h>
+
+#elif defined(BSD) && (BSD >= 199103)
+/* Do some BSD (4.3 code base or newer)specific autodetection. */
+#include <libcork/config/bsd.h>
 
 #endif  /* platforms */
 

--- a/make-dist.sh
+++ b/make-dist.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 PROJECT=libcork
 

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Usage: run.sh [debug|release] program arguments
 #
 # Runs a program from one of the build directories, with

--- a/version.sh
+++ b/version.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 # ----------------------------------------------------------------------
-# Copyright © 2011, RedJack, LLC.
+# Copyright © 2011-2013, RedJack, LLC.
 # All rights reserved.
 #
 # Please see the COPYING file in this distribution for license


### PR DESCRIPTION
Libcork fails to build on FreeBSD. There are some shell scripts and header files that do not check for BSD-specific locations of files or conditions.
