### PR TITLE
cork_path_dirname doesn't work on root directory

### DIFF
--- a/src/libcork/ds/buffer.c
+++ b/src/libcork/ds/buffer.c
@@ -96,6 +96,9 @@ void
 cork_buffer_clear(struct cork_buffer *buffer)
 {
     buffer->size = 0;
+    if (buffer->buf != NULL) {
+        ((char *) buffer->buf)[0] = '\0';
+    }
 }
 
 void
@@ -103,7 +106,11 @@ cork_buffer_truncate(struct cork_buffer *buffer, size_t length)
 {
     if (buffer->size > length) {
         buffer->size = length;
-        if (length > 0) {
+        if (length == 0) {
+            if (buffer->buf != NULL) {
+                ((char *) buffer->buf)[0] = '\0';
+            }
+        } else {
             ((char *) buffer->buf)[length] = '\0';
         }
     }

--- a/src/libcork/posix/files.c
+++ b/src/libcork/posix/files.c
@@ -218,7 +218,12 @@ cork_path_set_dirname(struct cork_path *path)
         cork_buffer_clear(&path->given);
     } else {
         size_t  offset = last_slash - given;
-        cork_buffer_truncate(&path->given, offset);
+        if (offset == 0) {
+            /* A special case for the immediate subdirectories of "/" */
+            cork_buffer_truncate(&path->given, 1);
+        } else {
+            cork_buffer_truncate(&path->given, offset);
+        }
     }
 }
 

--- a/tests/test-files.c
+++ b/tests/test-files.c
@@ -171,6 +171,11 @@ START_TEST(test_path_basename_01)
     test_basename("a/b", "b");
     test_basename("a/b/", "");
     test_basename("a/b/c", "c");
+    test_basename("/a", "a");
+    test_basename("/a/", "");
+    test_basename("/a/b", "b");
+    test_basename("/a/b/", "");
+    test_basename("/a/b/c", "c");
 }
 END_TEST
 
@@ -204,11 +209,17 @@ START_TEST(test_path_dirname_01)
     DESCRIBE_TEST;
     test_dirname(NULL, "");
     test_dirname("", "");
-    test_dirname("a", "a");
+    test_dirname("a", "");
     test_dirname("a/", "a");
     test_dirname("a/b", "a");
     test_dirname("a/b/", "a/b");
     test_dirname("a/b/c", "a/b");
+    test_dirname("/", "/");
+    test_dirname("/a", "/");
+    test_dirname("/a/", "/a");
+    test_dirname("/a/b", "/a");
+    test_dirname("/a/b/", "/a/b");
+    test_dirname("/a/b/c", "/a/b");
 }
 END_TEST
 


### PR DESCRIPTION
The cork_path_dirname function isn't returning the right results when applied to the root directory (`"/"`) or its immediate subdirectories (e.g., `"/usr"`).  You end up getting an empty path (`""`), when you should get the root directory (`"/"`).  (Note that it's customary to treat the root directory specially: `dirname("/") == "/"`.)
