### PR TITLE
Bit sets

### DIFF
--- a/docs/bitset.rst
+++ b/docs/bitset.rst
@@ -1,0 +1,47 @@
+.. _bits:
+
+********
+Bit sets
+********
+
+.. highlight:: c
+
+::
+
+  #include <libcork/ds.h>
+
+This sections defines a type for storing an array of bits.  This data structure
+is most often used to implement a set of integers.  It is particularly good when
+you expect your sets to be *dense*.  You should not use a bitset if the number
+of possibly elements is outrageously large, however, since that would cause your
+bitset to exhaust the available memory.
+
+.. type:: struct cork_bitset
+
+   An array of bits.  You should not allocate any instances of this type
+   yourself; use :c:func:`cork_bitset_new` instead.
+
+   .. member:: size_t bit_count
+
+      The number of bits that are included in this array.  (Each bit can be on
+      or off; this does not give you the number of bits that are *on*, it gives
+      you the number of bits in total, on or off.)
+
+
+.. function:: struct cork_bitset \*cork_bitset_new(size_t bit_count)
+
+   Create a new bitset with enough space to store the given number of bits.
+
+.. function:: void cork_bitset_free(struct cork_bitset \*set)
+
+   Free a bitset.
+
+.. function:: bool cork_bitset_get(struct cork_bitset \*set, size_t index)
+
+   Return whether the given bit is on or off in *set*.  It is your
+   responsibility to ensure that *index* is within the valid range for *set*.
+
+.. function:: void cork_bitset_set(struct cork_bitset \*set, size_t index, bool value)
+
+   Turn the given bit on or off in *set*.  It is your responsibility to ensure
+   that *index* is within the valid range for *set*.

--- a/docs/ds.rst
+++ b/docs/ds.rst
@@ -16,6 +16,7 @@ libcork includes implementations of a number of useful data structures.
    :maxdepth: 1
 
    array
+   bitset
    slice
    managed-buffer
    buffer

--- a/include/libcork/ds.h
+++ b/include/libcork/ds.h
@@ -14,6 +14,7 @@
 /*** include all of the parts ***/
 
 #include <libcork/ds/array.h>
+#include <libcork/ds/bitset.h>
 #include <libcork/ds/buffer.h>
 #include <libcork/ds/dllist.h>
 #include <libcork/ds/hash-table.h>

--- a/include/libcork/ds/bitset.h
+++ b/include/libcork/ds/bitset.h
@@ -1,0 +1,60 @@
+/* -*- coding: utf-8 -*-
+ * ----------------------------------------------------------------------
+ * Copyright © 2013, RedJack, LLC.
+ * All rights reserved.
+ *
+ * Please see the COPYING file in this distribution for license details.
+ * ----------------------------------------------------------------------
+ */
+
+#ifndef LIBCORK_DS_BITS_H
+#define LIBCORK_DS_BITS_H
+
+
+#include <libcork/core/api.h>
+#include <libcork/core/types.h>
+
+
+/*-----------------------------------------------------------------------
+ * Bit sets
+ */
+
+struct cork_bitset {
+    uint8_t  *bits;
+    size_t  bit_count;
+};
+
+CORK_API struct cork_bitset *
+cork_bitset_new(size_t bit_count);
+
+CORK_API void
+cork_bitset_free(struct cork_bitset *set);
+
+/* Extract the byte that contains a particular bit in an array. */
+#define cork_bitset_byte_for_bit(set, i) \
+    ((set)->bits[(i) / 8])
+
+/* Create a bit mask that extracts a particular bit from the byte that it lives
+ * in. */
+#define cork_bitset_pos_mask_for_bit(i) \
+    (0x80 >> ((i) % 8))
+
+/* Create a bit mask that extracts everything except for a particular bit from
+ * the byte that it lives in. */
+#define cork_bitset_neg_mask_for_bit(i) \
+    (~cork_bitset_pos_mask_for_bit(i))
+
+/* Return whether a particular bit is set in a byte array.  Bits are numbered
+ * from 0, in a big-endian order. */
+#define cork_bitset_get(set, i) \
+    ((cork_bitset_byte_for_bit(set, i) & cork_bitset_pos_mask_for_bit(i)) != 0)
+
+/* Set (or unset) a particular bit is set in a byte array.  Bits are numbered
+ * from 0, in a big-endian order. */
+#define cork_bitset_set(set, i, val) \
+    (cork_bitset_byte_for_bit(set, i) = \
+     (cork_bitset_byte_for_bit(set, i) & cork_bitset_neg_mask_for_bit(i)) \
+     | ((val)? cork_bitset_pos_mask_for_bit(i): 0))
+
+
+#endif /* LIBCORK_DS_BITS_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ set(LIBCORK_SRC
     libcork/core/mempool.c
     libcork/core/timestamp.c
     libcork/ds/array.c
+    libcork/ds/bitset.c
     libcork/ds/buffer.c
     libcork/ds/dllist.c
     libcork/ds/file-stream.c

--- a/src/libcork/ds/bitset.c
+++ b/src/libcork/ds/bitset.c
@@ -1,0 +1,40 @@
+/* -*- coding: utf-8 -*-
+ * ----------------------------------------------------------------------
+ * Copyright © 2013, RedJack, LLC.
+ * All rights reserved.
+ *
+ * Please see the COPYING file in this distribution for license details.
+ * ----------------------------------------------------------------------
+ */
+
+#include "libcork/core/allocator.h"
+#include "libcork/core/api.h"
+#include "libcork/core/types.h"
+#include "libcork/ds/bitset.h"
+
+
+static size_t
+bytes_needed(size_t bit_count)
+{
+    /* We need one byte for every bit... */
+    size_t  bytes_needed = bit_count / 8;
+    /* Plus one extra for the leftovers that don't fit into a whole byte. */
+    bytes_needed += ((bit_count % 8) > 0);
+    return bytes_needed;
+}
+
+struct cork_bitset *
+cork_bitset_new(size_t bit_count)
+{
+    struct cork_bitset  *set = cork_new(struct cork_bitset);
+    set->bits = cork_malloc(bytes_needed(bit_count));
+    set->bit_count = bit_count;
+    return set;
+}
+
+void
+cork_bitset_free(struct cork_bitset *set)
+{
+    free(set->bits);
+    free(set);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ macro(make_test test_name)
 endmacro(make_test)
 
 make_test(test-array)
+make_test(test-bitset)
 make_test(test-buffer)
 make_test(test-core)
 make_test(test-dllist)

--- a/tests/test-bitset.c
+++ b/tests/test-bitset.c
@@ -1,0 +1,101 @@
+/* -*- coding: utf-8 -*-
+ * ----------------------------------------------------------------------
+ * Copyright © 2013, RedJack, LLC.
+ * All rights reserved.
+ *
+ * Please see the COPYING file in this distribution for license details.
+ * ----------------------------------------------------------------------
+ */
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <check.h>
+
+#include "libcork/core/types.h"
+#include "libcork/ds/bitset.h"
+
+#include "helpers.h"
+
+
+/*-----------------------------------------------------------------------
+ * Bit sets
+ */
+
+static void
+test_bitset_of_size(size_t bit_count)
+{
+    size_t  i;
+    struct cork_bitset  *set = cork_bitset_new(bit_count);
+
+    for (i = 0; i < bit_count; i++) {
+        cork_bitset_set(set, i, true);
+        fail_unless(cork_bitset_get(set, i), "Unexpected value for bit %zu", i);
+    }
+
+    for (i = 0; i < bit_count; i++) {
+        cork_bitset_set(set, i, false);
+        fail_if(cork_bitset_get(set, i), "Unexpected value for bit %zu", i);
+    }
+
+    cork_bitset_free(set);
+}
+
+START_TEST(test_bitset)
+{
+    DESCRIBE_TEST;
+    /* Test a variety of sizes, with and without spillover bits. */
+    test_bitset_of_size(1);
+    test_bitset_of_size(2);
+    test_bitset_of_size(3);
+    test_bitset_of_size(4);
+    test_bitset_of_size(5);
+    test_bitset_of_size(6);
+    test_bitset_of_size(7);
+    test_bitset_of_size(8);
+    test_bitset_of_size(9);
+    test_bitset_of_size(10);
+    test_bitset_of_size(11);
+    test_bitset_of_size(12);
+    test_bitset_of_size(13);
+    test_bitset_of_size(14);
+    test_bitset_of_size(15);
+    test_bitset_of_size(16);
+    test_bitset_of_size(65535);
+    test_bitset_of_size(65536);
+    test_bitset_of_size(65537);
+}
+END_TEST
+
+
+/*-----------------------------------------------------------------------
+ * Testing harness
+ */
+
+Suite *
+test_suite()
+{
+    Suite  *s = suite_create("bits");
+
+    TCase  *tc_ds = tcase_create("bits");
+    tcase_add_test(tc_ds, test_bitset);
+    suite_add_tcase(s, tc_ds);
+
+    return s;
+}
+
+
+int
+main(int argc, const char **argv)
+{
+    int  number_failed;
+    Suite  *suite = test_suite();
+    SRunner  *runner = srunner_create(suite);
+
+    srunner_run_all(runner, CK_NORMAL);
+    number_failed = srunner_ntests_failed(runner);
+    srunner_free(runner);
+
+    return (number_failed == 0)? EXIT_SUCCESS: EXIT_FAILURE;
+}


### PR DESCRIPTION
This patch adds a new type for storing arrays of bits.  Each bit in the array can be on or off.  We always allocate space for all of the bits in the array, regardless of whether they are on or off.
