### PR TITLE
More efficient slices

### DIFF
--- a/include/libcork/ds/slice.h
+++ b/include/libcork/ds/slice.h
@@ -43,8 +43,16 @@ struct cork_slice_iface {
     /* Create a copy of a slice.  You can assume that offset and length
      * refer to a valid subset of the buffer. */
     int
-    (*copy)(struct cork_slice *self, struct cork_slice *dest,
+    (*copy)(struct cork_slice *dest, const struct cork_slice *self,
             size_t offset, size_t length);
+
+    /* Create a “light” copy of a slice.  A light copy is not allowed to exist
+     * longer than the slice that it was copied from, which can sometimes let
+     * you perform less work to produce the copy.  You can assume that offset
+     * and length refer to a valid subset of the buffer. */
+    int
+    (*light_copy)(struct cork_slice *dest, const struct cork_slice *self,
+                  size_t offset, size_t length);
 
     /* Update the current slice to point at a different subset.  You can
      * assume that offset and length refer to a valid subset of the
@@ -76,19 +84,35 @@ cork_slice_clear(struct cork_slice *slice);
 
 
 CORK_API int
-cork_slice_copy(struct cork_slice *dest, struct cork_slice *slice,
+cork_slice_copy(struct cork_slice *dest, const struct cork_slice *slice,
                 size_t offset, size_t length);
 
 #define cork_slice_copy_fast(dest, slice, offset, length) \
-    ((slice)->iface->copy((slice), (dest), (offset), (length)))
+    ((slice)->iface->copy((dest), (slice), (offset), (length)))
 
 CORK_API int
-cork_slice_copy_offset(struct cork_slice *dest, struct cork_slice *slice,
+cork_slice_copy_offset(struct cork_slice *dest, const struct cork_slice *slice,
                        size_t offset);
 
 #define cork_slice_copy_offset_fast(dest, slice, offset) \
     ((slice)->iface->copy \
-     ((slice), (dest), (offset), (slice)->size - (offset)))
+     ((dest), (slice), (offset), (slice)->size - (offset)))
+
+
+CORK_API int
+cork_slice_light_copy(struct cork_slice *dest, const struct cork_slice *slice,
+                      size_t offset, size_t length);
+
+#define cork_slice_light_copy_fast(dest, slice, offset, length) \
+    ((slice)->iface->light_copy((dest), (slice), (offset), (length)))
+
+CORK_API int
+cork_slice_light_copy_offset(struct cork_slice *dest,
+                             const struct cork_slice *slice, size_t offset);
+
+#define cork_slice_light_copy_offset_fast(dest, slice, offset) \
+    ((slice)->iface->light_copy \
+     ((dest), (slice), (offset), (slice)->size - (offset)))
 
 
 CORK_API int

--- a/src/libcork/ds/managed-buffer.c
+++ b/src/libcork/ds/managed-buffer.c
@@ -169,12 +169,12 @@ cork_managed_buffer__slice_free(struct cork_slice *self)
 }
 
 static int
-cork_managed_buffer__slice_copy(struct cork_slice *self,
-                                struct cork_slice *dest,
+cork_managed_buffer__slice_copy(struct cork_slice *dest,
+                                const struct cork_slice *src,
                                 size_t offset, size_t length)
 {
-    struct cork_managed_buffer  *mbuf = self->user_data;
-    dest->buf = self->buf + offset;
+    struct cork_managed_buffer  *mbuf = src->user_data;
+    dest->buf = src->buf + offset;
     dest->size = length;
     dest->iface = &CORK_MANAGED_BUFFER__SLICE;
     dest->user_data = cork_managed_buffer_ref(mbuf);
@@ -183,6 +183,7 @@ cork_managed_buffer__slice_copy(struct cork_slice *self,
 
 static struct cork_slice_iface  CORK_MANAGED_BUFFER__SLICE = {
     cork_managed_buffer__slice_free,
+    cork_managed_buffer__slice_copy,
     cork_managed_buffer__slice_copy,
     NULL
 };

--- a/src/libcork/ds/slice.c
+++ b/src/libcork/ds/slice.c
@@ -47,7 +47,7 @@ cork_slice_clear(struct cork_slice *slice)
 
 
 int
-cork_slice_copy(struct cork_slice *dest, struct cork_slice *slice,
+cork_slice_copy(struct cork_slice *dest, const struct cork_slice *slice,
                 size_t offset, size_t length)
 {
     if ((slice != NULL) &&
@@ -59,7 +59,7 @@ cork_slice_copy(struct cork_slice *dest, struct cork_slice *slice,
               offset, length,
               slice->buf + offset, length);
         */
-        return slice->iface->copy(slice, dest, offset, length);
+        return slice->iface->copy(dest, slice, offset, length);
     }
 
     else {
@@ -77,7 +77,7 @@ cork_slice_copy(struct cork_slice *dest, struct cork_slice *slice,
 
 
 int
-cork_slice_copy_offset(struct cork_slice *dest, struct cork_slice *slice,
+cork_slice_copy_offset(struct cork_slice *dest, const struct cork_slice *slice,
                        size_t offset)
 {
     if (slice == NULL) {
@@ -86,6 +86,51 @@ cork_slice_copy_offset(struct cork_slice *dest, struct cork_slice *slice,
         return -1;
     } else {
         return cork_slice_copy
+            (dest, slice, offset, slice->size - offset);
+    }
+}
+
+
+int
+cork_slice_light_copy(struct cork_slice *dest, const struct cork_slice *slice,
+                      size_t offset, size_t length)
+{
+    if ((slice != NULL) &&
+        (offset <= slice->size) &&
+        ((offset + length) <= slice->size)) {
+        /*
+        DEBUG("Slicing <%p:%zu> at %zu:%zu, gives <%p:%zu>",
+              slice->buf, slice->size,
+              offset, length,
+              slice->buf + offset, length);
+        */
+        return slice->iface->light_copy(dest, slice, offset, length);
+    }
+
+    else {
+        /*
+        DEBUG("Cannot slice <%p:%zu> at %zu:%zu",
+              slice->buf, slice->size,
+              offset, length);
+        */
+        cork_slice_clear(dest);
+        cork_slice_invalid_slice_set
+            ((slice == NULL)? 0: slice->size, offset, length);
+        return -1;
+    }
+}
+
+
+int
+cork_slice_light_copy_offset(struct cork_slice *dest,
+                             const struct cork_slice *slice, size_t offset)
+{
+    if (slice == NULL) {
+        cork_slice_clear(dest);
+        cork_slice_invalid_slice_set(0, offset, 0);
+        return -1;
+    } else {
+        return cork_slice_light_copy
             (dest, slice, offset, slice->size - offset);
     }
 }
@@ -144,7 +189,7 @@ cork_slice_finish(struct cork_slice *slice)
     DEBUG("Finalizing <%p:%zu>", dest->buf, dest->size);
     */
 
-    if (slice->iface->free != NULL) {
+    if (slice->iface != NULL && slice->iface->free != NULL) {
         slice->iface->free(slice);
     }
 
@@ -175,10 +220,10 @@ cork_slice_equal(const struct cork_slice *slice1,
 static struct cork_slice_iface  cork_static_slice;
 
 static int
-cork_static_slice_copy(struct cork_slice *self, struct cork_slice *dest,
+cork_static_slice_copy(struct cork_slice *dest, const struct cork_slice *src,
                        size_t offset, size_t length)
 {
-    dest->buf = self->buf + offset;
+    dest->buf = src->buf + offset;
     dest->size = length;
     dest->iface = &cork_static_slice;
     dest->user_data = NULL;
@@ -186,7 +231,10 @@ cork_static_slice_copy(struct cork_slice *self, struct cork_slice *dest,
 }
 
 static struct cork_slice_iface  cork_static_slice = {
-    NULL, cork_static_slice_copy, NULL
+    NULL,
+    cork_static_slice_copy,
+    cork_static_slice_copy,
+    NULL
 };
 
 void
@@ -206,19 +254,36 @@ cork_slice_init_static(struct cork_slice *dest, const void *buf, size_t size)
 static struct cork_slice_iface  cork_copy_once_slice;
 
 static int
-cork_copy_once_slice__copy(struct cork_slice *self, struct cork_slice *dest,
+cork_copy_once_slice__copy(struct cork_slice *dest,
+                           const struct cork_slice *src,
                            size_t offset, size_t length)
 {
     struct cork_managed_buffer  *mbuf =
-        cork_managed_buffer_new_copy(self->buf, self->size);
+        cork_managed_buffer_new_copy(src->buf, src->size);
     rii_check(cork_managed_buffer_slice(dest, mbuf, offset, length));
-    rii_check(cork_managed_buffer_slice(self, mbuf, 0, self->size));
+    rii_check(cork_managed_buffer_slice
+              ((struct cork_slice *) src, mbuf, 0, src->size));
     cork_managed_buffer_unref(mbuf);
     return 0;
 }
 
+static int
+cork_copy_once_slice__light_copy(struct cork_slice *dest,
+                                 const struct cork_slice *src,
+                                 size_t offset, size_t length)
+{
+    dest->buf = src->buf + offset;
+    dest->size = length;
+    dest->iface = &cork_copy_once_slice;
+    dest->user_data = NULL;
+    return 0;
+}
+
 static struct cork_slice_iface  cork_copy_once_slice = {
-    NULL, cork_copy_once_slice__copy, NULL
+    NULL,
+    cork_copy_once_slice__copy,
+    cork_copy_once_slice__light_copy,
+    NULL
 };
 
 void

--- a/tests/test-slice.c
+++ b/tests/test-slice.c
@@ -28,14 +28,19 @@ START_TEST(test_static_slice)
     static char  SRC[] = "Here is some text.";
     size_t  SRC_LEN = sizeof(SRC) - 1;
 
-    struct cork_slice  slice1;
-    struct cork_slice  slice2;
-    cork_slice_init_static(&slice1, SRC, SRC_LEN);
-    fail_if_error(cork_slice_copy(&slice2, &slice1, 8, 4));
-    fail_if_error(cork_slice_slice(&slice1, 8, 4));
-    fail_unless(cork_slice_equal(&slice1, &slice2), "Slices should be equal");
-    cork_slice_finish(&slice1);
-    cork_slice_finish(&slice2);
+    struct cork_slice  slice;
+    struct cork_slice  copy1;
+    struct cork_slice  lcopy1;
+    cork_slice_init_static(&slice, SRC, SRC_LEN);
+    fail_if_error(cork_slice_copy(&copy1, &slice, 8, 4));
+    fail_if_error(cork_slice_light_copy(&lcopy1, &slice, 8, 4));
+    fail_if_error(cork_slice_slice(&slice, 8, 4));
+    fail_unless(cork_slice_equal(&slice, &copy1), "Slices should be equal");
+    fail_unless(cork_slice_equal(&slice, &lcopy1), "Slices should be equal");
+    /* We have to finish lcopy1 first, since it's a light copy. */
+    cork_slice_finish(&lcopy1);
+    cork_slice_finish(&slice);
+    cork_slice_finish(&copy1);
 }
 END_TEST
 
@@ -49,28 +54,52 @@ START_TEST(test_copy_once_slice)
     static char  SRC[] = "Here is some text.";
     size_t  SRC_LEN = sizeof(SRC) - 1;
 
-    struct cork_slice  slice1;
-    struct cork_slice  slice2;
-    struct cork_slice  slice3;
+    struct cork_slice  slice;
+    struct cork_slice  copy1;
+    struct cork_slice  copy2;
+    struct cork_slice  lcopy1;
+    struct cork_slice  lcopy2;
 
-    cork_slice_init_copy_once(&slice1, SRC, SRC_LEN);
-    fail_unless(slice1.buf == SRC, "Unexpected slice buffer");
+    cork_slice_init_copy_once(&slice, SRC, SRC_LEN);
+    fail_unless(slice.buf == SRC, "Unexpected slice buffer");
 
-    fail_if_error(cork_slice_copy(&slice2, &slice1, 8, 4));
-    fail_if_error(cork_slice_slice(&slice1, 8, 4));
-    fail_unless(slice1.buf != SRC, "Unexpected slice buffer");
-    fail_unless(slice1.buf == slice2.buf, "Unexpected slice buffer");
-    fail_unless(cork_slice_equal(&slice1, &slice2), "Slices should be equal");
+    fail_if_error(cork_slice_light_copy(&lcopy1, &slice, 8, 4));
+    /* We should still be using the original SRC buffer directly, since we only
+     * created a light copy. */
+    fail_unless(slice.buf == SRC, "Unexpected slice buffer");
+    fail_unless(slice.buf + 8 == lcopy1.buf, "Unexpected slice buffer");
 
-    fail_if_error(cork_slice_copy(&slice3, &slice1, 0, 4));
-    fail_unless(slice1.buf == slice3.buf, "Unexpected slice buffer");
-    fail_unless(slice2.buf == slice3.buf, "Unexpected slice buffer");
-    fail_unless(cork_slice_equal(&slice1, &slice3), "Slices should be equal");
-    fail_unless(cork_slice_equal(&slice2, &slice3), "Slices should be equal");
+    fail_if_error(cork_slice_copy(&copy1, &slice, 8, 4));
+    fail_if_error(cork_slice_slice(&slice, 8, 4));
+    /* Once we create a full copy, the content should have been moved into a
+     * managed buffer, which will exist somewhere else in memory than the
+     * original SRC pointer. */
+    fail_unless(slice.buf != SRC, "Unexpected slice buffer");
+    fail_unless(slice.buf == copy1.buf, "Unexpected slice buffer");
+    /* The light copy that we made previously won't have been moved over to the
+     * new managed buffer, though. */
+    fail_unless(cork_slice_equal(&slice, &copy1), "Slices should be equal");
 
-    cork_slice_finish(&slice1);
-    cork_slice_finish(&slice2);
-    cork_slice_finish(&slice3);
+    /* Once we've switched over to the managed buffer, a new light copy should
+     * still point into the managed buffer. */
+    fail_if_error(cork_slice_light_copy(&lcopy2, &slice, 0, 4));
+    fail_unless(slice.buf != SRC, "Unexpected slice buffer");
+    fail_unless(slice.buf == lcopy2.buf, "Unexpected slice buffer");
+
+    fail_if_error(cork_slice_copy(&copy2, &slice, 0, 4));
+    /* The second full copy should not create a new managed buffer, it should
+     * just increment the existing managed buffer's refcount. */
+    fail_unless(slice.buf == copy2.buf, "Unexpected slice buffer");
+    fail_unless(copy1.buf == copy2.buf, "Unexpected slice buffer");
+    fail_unless(cork_slice_equal(&slice, &copy2), "Slices should be equal");
+    fail_unless(cork_slice_equal(&copy1, &copy2), "Slices should be equal");
+
+    /* We have to finish the light copies first. */
+    cork_slice_finish(&lcopy1);
+    cork_slice_finish(&lcopy2);
+    cork_slice_finish(&slice);
+    cork_slice_finish(&copy1);
+    cork_slice_finish(&copy2);
 }
 END_TEST
 


### PR DESCRIPTION
These two patches add some efficiency to the slice interface.  You can now make "light" copies of a slice, which means that you (as the caller) are guaranteeing that the new copy cannot possibly outlive the source slice.  Some slice implementations are able to make light copies more efficiently than the previous "normal" or "heavy" copies.

In particular, the new "copy-once" slice is used to wrap an existing buffer.  This is only valid if the caller guarantees that the buffer will outlive the slice.  If you make a light copy of this kind of slice, the guarantee extends to the light copy: since the buffer outlives the original slice, and the original slice outlives the light copy, then the buffer outlives the light copy.  So for light copies of a copy-once slice, we can use the same pointer, and not have to make a real copy of the data.

For a heavy copy of a copy-once slice, however, we can't make any guarantees about how the original data buffer relates to the copied slice.  So for those, we have to actually copy the underlying buffer.  We actually a managed buffer, which lets us bump refcounts for any further copies.  Hence the name "copy-once" — with a copy-once slice, we'll make at most one copy of the underlying wrapped buffer, and only do that when needed.
