### PR TITLE
Allow 0-length managed buffer slices

### DIFF
--- a/src/libcork/ds/managed-buffer.c
+++ b/src/libcork/ds/managed-buffer.c
@@ -195,7 +195,7 @@ cork_managed_buffer_slice(struct cork_slice *dest,
                           size_t offset, size_t length)
 {
     if ((buffer != NULL) &&
-        (offset < buffer->size) &&
+        (offset <= buffer->size) &&
         ((offset + length) <= buffer->size)) {
         /*
         DEBUG("Slicing [%p:%zu] at %zu:%zu, gives <%p:%zu>",


### PR DESCRIPTION
The general `cork_slice_*` functions allow you to create a 0-length slice, but the constructor for creating a new slice from a managed buffer does not.  We should consistently allow this.
