### PR TITLE
Initialize bitsets to known state

### DIFF
--- a/docs/bitset.rst
+++ b/docs/bitset.rst
@@ -30,7 +30,8 @@ bitset to exhaust the available memory.
 
 .. function:: struct cork_bitset \*cork_bitset_new(size_t bit_count)
 
-   Create a new bitset with enough space to store the given number of bits.
+   Create a new bitset with enough space to store the given number of bits.  All
+   bits will be initialized to ``0``.
 
 .. function:: void cork_bitset_free(struct cork_bitset \*set)
 
@@ -45,3 +46,7 @@ bitset to exhaust the available memory.
 
    Turn the given bit on or off in *set*.  It is your responsibility to ensure
    that *index* is within the valid range for *set*.
+
+.. function:: void cork_bitset_clear(struct cork_bitset \*set)
+
+   Turn off of the bits in *set*.

--- a/include/libcork/ds/bitset.h
+++ b/include/libcork/ds/bitset.h
@@ -22,6 +22,7 @@
 struct cork_bitset {
     uint8_t  *bits;
     size_t  bit_count;
+    size_t  byte_count;
 };
 
 CORK_API struct cork_bitset *
@@ -29,6 +30,9 @@ cork_bitset_new(size_t bit_count);
 
 CORK_API void
 cork_bitset_free(struct cork_bitset *set);
+
+CORK_API void
+cork_bitset_clear(struct cork_bitset *set);
 
 /* Extract the byte that contains a particular bit in an array. */
 #define cork_bitset_byte_for_bit(set, i) \

--- a/src/libcork/ds/bitset.c
+++ b/src/libcork/ds/bitset.c
@@ -7,6 +7,8 @@
  * ----------------------------------------------------------------------
  */
 
+#include <string.h>
+
 #include "libcork/core/allocator.h"
 #include "libcork/core/api.h"
 #include "libcork/core/types.h"
@@ -27,8 +29,10 @@ struct cork_bitset *
 cork_bitset_new(size_t bit_count)
 {
     struct cork_bitset  *set = cork_new(struct cork_bitset);
-    set->bits = cork_malloc(bytes_needed(bit_count));
     set->bit_count = bit_count;
+    set->byte_count = bytes_needed(bit_count);
+    set->bits = cork_malloc(set->byte_count);
+    memset(set->bits, 0, set->byte_count);
     return set;
 }
 
@@ -37,4 +41,10 @@ cork_bitset_free(struct cork_bitset *set)
 {
     free(set->bits);
     free(set);
+}
+
+void
+cork_bitset_clear(struct cork_bitset *set)
+{
+    memset(set->bits, 0, set->byte_count);
 }


### PR DESCRIPTION
The `cork_bitset_new` function now ensures that all of the bits in the new bitset are cleared.  This ensures that the bitset is in a known, well-defined state to begin with.  There's also a new `cork_bitset_clear` function, which lets you reset and reuse a bitset.
