### PR TITLE
128-bit integers on earlier versions of GCC

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -89,6 +89,7 @@ macros to choose among the possible implementations.
    .. _atomic intrinsics: http://gcc.gnu.org/onlinedocs/gcc-4.1.2/gcc/Atomic-Builtins.html
 
 
+
 .. macro:: CORK_CONFIG_HAVE_GCC_INT128
 
    Whether the GCC-style `128-bit integer`_ types (``__int128`` and ``unsigned
@@ -96,6 +97,14 @@ macros to choose among the possible implementations.
    specifically GCC.)  Should be defined to ``0`` or ``1``.
 
    .. _128-bit integer: http://gcc.gnu.org/onlinedocs/gcc/_005f_005fint128.html
+
+
+.. macro:: CORK_CONFIG_HAVE_GCC_MODE_ATTRIBUTE
+
+   Whether GCC-style `machine modes`_ are available.  (This doesn't imply that
+   the compiler is specifically GCC.)  Should be defined to ``0`` or ``1``.
+
+   .. _machine modes: http://gcc.gnu.org/onlinedocs/gcc-4.8.1/gccint/Machine-Modes.html#Machine-Modes
 
 
 .. macro:: CORK_CONFIG_HAVE_GCC_STATEMENT_EXPRS

--- a/include/libcork/config/gcc.h
+++ b/include/libcork/config/gcc.h
@@ -51,11 +51,19 @@
 #define CORK_CONFIG_HAVE_GCC_ATTRIBUTES  0
 #endif
 
-/* __int128 seems to be available on 64-bit platforms as of GCC 4.1 */
-#if CORK_CONFIG_ARCH_X64 && CORK_CONFIG_GCC_VERSION >= 40100
+/* __int128 seems to be available on 64-bit platforms as of GCC 4.6.  The
+ * attribute((mode(TI))) syntax seems to be available as of 4.1. */
+
+#if CORK_CONFIG_ARCH_X64 && CORK_CONFIG_GCC_VERSION >= 40600
 #define CORK_CONFIG_HAVE_GCC_INT128  1
 #else
 #define CORK_CONFIG_HAVE_GCC_INT128  0
+#endif
+
+#if CORK_CONFIG_ARCH_X64 && CORK_CONFIG_GCC_VERSION >= 40100
+#define CORK_CONFIG_HAVE_GCC_MODE_ATTRIBUTE  1
+#else
+#define CORK_CONFIG_HAVE_GCC_MODE_ATTRIBUTE  0
 #endif
 
 /* Statement expressions have been available since GCC 3.1. */

--- a/include/libcork/core/u128.h
+++ b/include/libcork/core/u128.h
@@ -28,7 +28,13 @@ typedef struct {
         struct { uint64_t lo; uint64_t hi; } be64;
 #endif
 #if CORK_CONFIG_HAVE_GCC_INT128
+#define CORK_U128_HAVE_U128  1
         unsigned __int128  u128;
+#elif CORK_CONFIG_HAVE_GCC_MODE_ATTRIBUTE
+#define CORK_U128_HAVE_U128  1
+        unsigned int  u128 __attribute__((mode(TI)));
+#else
+#define CORK_U128_HAVE_U128  0
 #endif
     } _;
 } cork_u128;
@@ -89,7 +95,7 @@ static cork_u128
 cork_u128_add(cork_u128 a, cork_u128 b)
 {
     cork_u128  result;
-#if CORK_CONFIG_HAVE_GCC_INT128
+#if CORK_U128_HAVE_U128
     result._.u128 = a._.u128 + b._.u128;
 #else
     result._.be64.lo = a._.be64.lo + b._.be64.lo;
@@ -104,7 +110,7 @@ static cork_u128
 cork_u128_sub(cork_u128 a, cork_u128 b)
 {
     cork_u128  result;
-#if CORK_CONFIG_HAVE_GCC_INT128
+#if CORK_U128_HAVE_U128
     result._.u128 = a._.u128 - b._.u128;
 #else
     result._.be64.lo = a._.be64.lo - b._.be64.lo;
@@ -119,7 +125,7 @@ CORK_ATTR_UNUSED
 static bool
 cork_u128_eq(cork_u128 a, cork_u128 b)
 {
-#if CORK_CONFIG_HAVE_GCC_INT128
+#if CORK_U128_HAVE_U128
     return (a._.u128 == b._.u128);
 #else
     return (a._.be64.hi == b._.be64.hi) && (a._.be64.lo == b._.be64.lo);
@@ -130,7 +136,7 @@ CORK_ATTR_UNUSED
 static bool
 cork_u128_ne(cork_u128 a, cork_u128 b)
 {
-#if CORK_CONFIG_HAVE_GCC_INT128
+#if CORK_U128_HAVE_U128
     return (a._.u128 != b._.u128);
 #else
     return (a._.be64.hi != b._.be64.hi) || (a._.be64.lo != b._.be64.lo);
@@ -141,7 +147,7 @@ CORK_ATTR_UNUSED
 static bool
 cork_u128_lt(cork_u128 a, cork_u128 b)
 {
-#if CORK_CONFIG_HAVE_GCC_INT128
+#if CORK_U128_HAVE_U128
     return (a._.u128 < b._.u128);
 #else
     if (a._.be64.hi == b._.be64.hi) {
@@ -156,7 +162,7 @@ CORK_ATTR_UNUSED
 static bool
 cork_u128_le(cork_u128 a, cork_u128 b)
 {
-#if CORK_CONFIG_HAVE_GCC_INT128
+#if CORK_U128_HAVE_U128
     return (a._.u128 <= b._.u128);
 #else
     if (a._.be64.hi == b._.be64.hi) {
@@ -171,7 +177,7 @@ CORK_ATTR_UNUSED
 static bool
 cork_u128_gt(cork_u128 a, cork_u128 b)
 {
-#if CORK_CONFIG_HAVE_GCC_INT128
+#if CORK_U128_HAVE_U128
     return (a._.u128 > b._.u128);
 #else
     if (a._.be64.hi == b._.be64.hi) {
@@ -186,7 +192,7 @@ CORK_ATTR_UNUSED
 static bool
 cork_u128_ge(cork_u128 a, cork_u128 b)
 {
-#if CORK_CONFIG_HAVE_GCC_INT128
+#if CORK_U128_HAVE_U128
     return (a._.u128 >= b._.u128);
 #else
     if (a._.be64.hi == b._.be64.hi) {


### PR DESCRIPTION
Looks like earlier versions of GCC (such as 4.4.7, which is the version installed on CentOS 6.4) don't support the `__int128` type:

```
[  1%] Building C object src/CMakeFiles/embedded_libcork.dir/libcork/cli/commands.c.o
In file included from /home/vagrant/git/libcork/src/../include/libcork/core/hash.h:18,
                 from /home/vagrant/git/libcork/src/../include/libcork/core.h:21,
                 from /home/vagrant/git/libcork/src/libcork/cli/commands.c:16:
/home/vagrant/git/libcork/src/../include/libcork/core/u128.h:31: error: expected ‘:’, ‘,’, ‘;’, ‘}’ or ‘__attribute__’ before ‘u128’
```
