### PR TITLE
Hide mempool implementation details

### DIFF
--- a/include/libcork/ds/hash-table.h
+++ b/include/libcork/ds/hash-table.h
@@ -52,7 +52,7 @@ struct cork_hash_table {
     /* A comparator function. */
     cork_hash_table_comparator  comparator;
     /* A memory pool for the hash table entries */
-    struct cork_mempool  entry_mempool;
+    struct cork_mempool  *entry_mempool;
 };
 
 

--- a/src/libcork/ds/hash-table.c
+++ b/src/libcork/ds/hash-table.c
@@ -92,7 +92,7 @@ cork_hash_table_init(struct cork_hash_table *table,
     table->entry_count = 0;
     table->hasher = hasher;
     table->comparator = comparator;
-    cork_mempool_init(&table->entry_mempool, struct cork_hash_table_entry);
+    table->entry_mempool = cork_mempool_new(struct cork_hash_table_entry);
 }
 
 
@@ -123,7 +123,7 @@ cork_hash_table_clear(struct cork_hash_table *table)
             struct cork_dllist_item  *next = curr->next;
 
             DEBUG("    Freeing entry %p", entry);
-            cork_mempool_free(&table->entry_mempool, entry);
+            cork_mempool_free_object(table->entry_mempool, entry);
 
             curr = next;
         }
@@ -138,7 +138,7 @@ void
 cork_hash_table_done(struct cork_hash_table *table)
 {
     cork_hash_table_clear(table);
-    cork_mempool_done(&table->entry_mempool);
+    cork_mempool_free(table->entry_mempool);
     free(table->bins);
 }
 
@@ -291,7 +291,7 @@ cork_hash_table_get_or_create(struct cork_hash_table *table,
 
     DEBUG("    Allocating new entry");
     struct cork_hash_table_entry  *entry =
-        cork_mempool_new(&table->entry_mempool);
+        cork_mempool_new_object(table->entry_mempool);
 
     DEBUG("    Created new entry %p", entry);
     entry->hash = hash_value;
@@ -369,7 +369,7 @@ cork_hash_table_put(struct cork_hash_table *table,
 
     DEBUG("    Allocating new entry");
     struct cork_hash_table_entry  *entry =
-        cork_mempool_new(&table->entry_mempool);
+        cork_mempool_new_object(table->entry_mempool);
 
     DEBUG("    Created new entry %p", entry);
     entry->hash = hash_value;
@@ -429,7 +429,7 @@ cork_hash_table_delete(struct cork_hash_table *table, const void *key,
             table->entry_count--;
 
             DEBUG("    Freeing entry %p", entry);
-            cork_mempool_free(&table->entry_mempool, entry);
+            cork_mempool_free_object(table->entry_mempool, entry);
             return true;
         }
 
@@ -469,7 +469,7 @@ cork_hash_table_map(struct cork_hash_table *table,
                     (curr, struct cork_hash_table_entry, siblings);
                 DEBUG("      Delete requested");
                 cork_dllist_remove(curr);
-                cork_mempool_free(&table->entry_mempool, entry);
+                cork_mempool_free_object(table->entry_mempool, entry);
                 table->entry_count--;
             }
 

--- a/tests/test-mempool.c
+++ b/tests/test-mempool.c
@@ -31,63 +31,62 @@ START_TEST(test_mempool_01)
 {
 #define OBJECT_COUNT  16
     DESCRIBE_TEST;
-    struct cork_mempool  mp;
+    struct cork_mempool  *mp;
     /* Small enough that we'll have to allocate a couple of blocks */
-    cork_mempool_init_ex(&mp, int64_t, 64);
+    mp = cork_mempool_new_ex(int64_t, 64);
 
     size_t  i;
     int64_t  *objects[OBJECT_COUNT];
     for (i = 0; i < OBJECT_COUNT; i++) {
-        fail_if((objects[i] = cork_mempool_new(&mp)) == NULL,
+        fail_if((objects[i] = cork_mempool_new_object(mp)) == NULL,
                 "Cannot allocate object #%zu", i);
     }
 
     for (i = 0; i < OBJECT_COUNT; i++) {
-        cork_mempool_free(&mp, objects[i]);
+        cork_mempool_free_object(mp, objects[i]);
     }
 
     for (i = 0; i < OBJECT_COUNT; i++) {
-        fail_if((objects[i] = cork_mempool_new(&mp)) == NULL,
+        fail_if((objects[i] = cork_mempool_new_object(mp)) == NULL,
                 "Cannot reallocate object #%zu", i);
     }
 
     for (i = 0; i < OBJECT_COUNT; i++) {
-        cork_mempool_free(&mp, objects[i]);
+        cork_mempool_free_object(mp, objects[i]);
     }
 
-    cork_mempool_done(&mp);
+    cork_mempool_free(mp);
 }
 END_TEST
 
 START_TEST(test_mempool_fail_01)
 {
     DESCRIBE_TEST;
-    struct cork_mempool  mp;
-    cork_mempool_init(&mp, int64_t);
+    struct cork_mempool  *mp;
+    mp = cork_mempool_new(int64_t);
 
     int64_t  *obj;
-    fail_if((obj = cork_mempool_new(&mp)) == NULL,
+    fail_if((obj = cork_mempool_new_object(mp)) == NULL,
             "Cannot allocate object");
 
     /* This should raise an assertion since we never freed obj. */
-    cork_mempool_done(&mp);
+    cork_mempool_free(mp);
 }
 END_TEST
 
 
-static size_t  done_call_count = 0;
-
 static void
-int64_init(void *vobj)
+int64_init(void *user_data, void *vobj)
 {
     int64_t  *obj = vobj;
     *obj = 12;
 }
 
 static void
-int64_done(void *vobj)
+int64_done(void *user_data, void *vobj)
 {
-    done_call_count++;
+    size_t  *done_call_count = user_data;
+    (*done_call_count)++;
 }
 
 /* This is based on our knowledge of the internal structure of a memory
@@ -100,13 +99,14 @@ START_TEST(test_mempool_reuse_01)
 {
 #define BLOCK_SIZE  64
     DESCRIBE_TEST;
-    struct cork_mempool  mp;
-    cork_mempool_init_ex(&mp, int64_t, BLOCK_SIZE);
-    mp.init_object = int64_init;
-    mp.done_object = int64_done;
+    size_t  done_call_count = 0;
+    struct cork_mempool  *mp;
+    mp = cork_mempool_new_ex(int64_t, BLOCK_SIZE);
+    cork_mempool_set_callbacks
+        (mp, &done_call_count, NULL, int64_init, int64_done);
 
     int64_t  *obj;
-    fail_if((obj = cork_mempool_new(&mp)) == NULL,
+    fail_if((obj = cork_mempool_new_object(mp)) == NULL,
             "Cannot allocate object");
 
     /* The init_object function sets the value to 12 */
@@ -116,13 +116,13 @@ START_TEST(test_mempool_reuse_01)
      * Since we know memory pools are LIFO, we should get back the same
      * object, unchanged. */
     *obj = 42;
-    cork_mempool_free(&mp, obj);
-    fail_if((obj = cork_mempool_new(&mp)) == NULL,
+    cork_mempool_free_object(mp, obj);
+    fail_if((obj = cork_mempool_new_object(mp)) == NULL,
             "Cannot allocate object");
     fail_unless(*obj == 42, "Unexpected value %" PRId64, *obj);
 
-    cork_mempool_free(&mp, obj);
-    cork_mempool_done(&mp);
+    cork_mempool_free_object(mp, obj);
+    cork_mempool_free(mp);
 
     fail_unless(done_call_count ==
                 OBJECTS_PER_BLOCK(BLOCK_SIZE, sizeof(int64_t)),


### PR DESCRIPTION
The `cork_mempool` type is now completely opaque, which moves us one step closer to declaring a stable ABI for libcork.  This means that you can no longer embed a `cork_mempool` directly into your own types.  This gives us more flexibility in the future to change the implementation without breaking existing code.

(The main reason for allowing embedded `cork_mempool` objects was to let us implement `cork_mempool_new_object` as a static inline function.  But that's not really useful; the performance benefit is negligible, and it complicates the API.  So that's now a regular CORK_API function.)

As part of this update, the initialization and finalization callbacks now include a `user_data` parameter, like all good callbacks should.  (We already had function pointer types for these callbacks, we just needed to use them!)

And lastly, the functions for allocating and freeing an object in the memory pool have been renamed to `cork_mempool_new_object` and `cork_mempool_free_object`.  After all, they weren't creating or freeing the memory pool itself...
