### PR TITLE
Thread-safe subprocesses

### DIFF
--- a/include/libcork/os/subprocess.h
+++ b/include/libcork/os/subprocess.h
@@ -138,6 +138,21 @@ cork_subprocess_new_exec(struct cork_exec *exec,
 CORK_API void
 cork_subprocess_free(struct cork_subprocess *sub);
 
+CORK_API int
+cork_subprocess_start(struct cork_subprocess *sub);
+
+CORK_API bool
+cork_subprocess_is_finished(struct cork_subprocess *sub);
+
+CORK_API int
+cork_subprocess_abort(struct cork_subprocess *sub);
+
+CORK_API bool
+cork_subprocess_drain(struct cork_subprocess *sub);
+
+CORK_API int
+cork_subprocess_wait(struct cork_subprocess *sub);
+
 
 /*-----------------------------------------------------------------------
  * Groups of subprocesses
@@ -165,7 +180,7 @@ cork_subprocess_group_is_finished(struct cork_subprocess_group *group);
 CORK_API int
 cork_subprocess_group_abort(struct cork_subprocess_group *group);
 
-CORK_API int
+CORK_API bool
 cork_subprocess_group_drain(struct cork_subprocess_group *group);
 
 CORK_API int


### PR DESCRIPTION
The `cork_subprocess` functions now work with multiple threads.  You can also more easily run a single subprocess; you don't need to create a one-element subprocess group any more.

The new implementation is also much simpler; before, we were using a select loop in `cork_subprocess_wait` to sleep until there was something interesting to do.  We also explicitly handled the `SIGCHLD` signal to reap any processes that just finished.  We now use a more naive busy loop; each call to `cork_subprocress_drain` tries to read data from the subprocess's stdout and stderr streams, and then checks if the subprocess has exited, both in a non-blocking fashion.  There is then a busy loop in `cork_subprocess_wait` that drains the subprocess repeatedly until it's finished.  We use the “hybrid yield strategy” from [here](http://www.1024cores.net/home/lock-free-algorithms/tricks/spinning) to make sure that we don't consume too much CPU if the subprocess is long running and doesn't produce any output.
