### PR TITLE
Allocate ring buffers on the heap

### DIFF
--- a/docs/ring-buffer.rst
+++ b/docs/ring-buffer.rst
@@ -30,14 +30,22 @@ Ring buffers
 
 
 .. function:: int cork_ring_buffer_init(struct cork_ring_buffer \*buf, size_t size)
+              struct cork_ring_buffer \*cork_ring_buffer_new(size_t size)
 
-   Initializes a ring buffer instance, having a capacity of *size*
-   elements.  If we cannot initialize the ring buffer, we'll return
-   ``1``.
+   Initializes a ring buffer instance, having a capacity of *size* elements.
+   The ``_init`` version should be used to initialize an instance you
+   allocated yourself on the stack.  The ``_new`` version will allocate an
+   instance from the heap.  If memory allocation fails in either function,
+   the program will abort with an error.
+
 
 .. function:: void cork_ring_buffer_done(struct cork_ring_buffer \*buf)
+              void cork_ring_buffer_free(struct cork_ring_buffer \*buf)
 
-   Finalizes a ring buffer instance.  Nothing special is done to any
+   Finalizes a ring buffer instance.  The ``_done`` variant should be used to
+   finalize an instance that you allocated yourself (i.e., on the stack).  The
+   ``_free`` version should be used on instance allocated on the heap by using
+   :c:func:`cork_hash_table_new()`.  Nothing special is done to any
    remaining elements in the ring buffer; if they need to be finalized,
    you should do that yourself before calling this function.
 

--- a/include/libcork/ds/ring-buffer.h
+++ b/include/libcork/ds/ring-buffer.h
@@ -33,8 +33,14 @@ struct cork_ring_buffer {
 CORK_API int
 cork_ring_buffer_init(struct cork_ring_buffer *buf, size_t size);
 
+CORK_API struct cork_ring_buffer *
+cork_ring_buffer_new(size_t size);
+
 CORK_API void
 cork_ring_buffer_done(struct cork_ring_buffer *buf);
+
+CORK_API void
+cork_ring_buffer_free(struct cork_ring_buffer *buf);
 
 
 #define cork_ring_buffer_is_empty(buf) ((buf)->size == 0)

--- a/src/libcork/ds/ring-buffer.c
+++ b/src/libcork/ds/ring-buffer.c
@@ -10,6 +10,7 @@
 
 #include <stdlib.h>
 
+#include "libcork/core/allocator.h"
 #include "libcork/core/types.h"
 #include "libcork/ds/ring-buffer.h"
 
@@ -17,11 +18,7 @@
 int
 cork_ring_buffer_init(struct cork_ring_buffer *self, size_t size)
 {
-    self->elements = calloc(size, sizeof(void *));
-    if (self->elements == NULL) {
-        return -1;
-    }
-
+    self->elements = cork_calloc(size, sizeof(void *));
     self->allocated_size = size;
     self->size = 0;
     self->read_index = 0;
@@ -29,10 +26,25 @@ cork_ring_buffer_init(struct cork_ring_buffer *self, size_t size)
     return 0;
 }
 
+struct cork_ring_buffer *
+cork_ring_buffer_new(size_t size)
+{
+    struct cork_ring_buffer  *buf = cork_new(struct cork_ring_buffer);
+    cork_ring_buffer_init(buf, size);
+    return buf;
+}
+
 void
 cork_ring_buffer_done(struct cork_ring_buffer *self)
 {
     free(self->elements);
+}
+
+void
+cork_ring_buffer_free(struct cork_ring_buffer *buf)
+{
+    cork_ring_buffer_done(buf);
+    free(buf);
 }
 
 int

--- a/tests/test-ring-buffer.c
+++ b/tests/test-ring-buffer.c
@@ -22,7 +22,7 @@
  * Ring buffers
  */
 
-START_TEST(test_ring_buffer)
+START_TEST(test_ring_buffer_1)
 {
     struct cork_ring_buffer  buf;
     cork_ring_buffer_init(&buf, 4);
@@ -68,6 +68,49 @@ START_TEST(test_ring_buffer)
 END_TEST
 
 
+START_TEST(test_ring_buffer_2)
+{
+    struct cork_ring_buffer  *buf = cork_ring_buffer_new(4);
+
+    fail_unless(cork_ring_buffer_add(buf, (void *) 1) == 0,
+                "Cannot add to ring buffer");
+    fail_unless(cork_ring_buffer_add(buf, (void *) 2) == 0,
+                "Cannot add to ring buffer");
+    fail_unless(cork_ring_buffer_add(buf, (void *) 3) == 0,
+                "Cannot add to ring buffer");
+    fail_unless(cork_ring_buffer_add(buf, (void *) 4) == 0,
+                "Cannot add to ring buffer");
+    fail_if(cork_ring_buffer_add(buf, (void *) 5) == 0,
+            "Shouldn't be able to add to ring buffer");
+
+    fail_unless(((intptr_t) cork_ring_buffer_peek(buf)) == 1,
+                "Unexpected head of ring buffer (peek)");
+    fail_unless(((intptr_t) cork_ring_buffer_pop(buf)) == 1,
+                "Unexpected head of ring buffer (pop)");
+    fail_unless(((intptr_t) cork_ring_buffer_pop(buf)) == 2,
+                "Unexpected head of ring buffer (pop)");
+
+    fail_unless(cork_ring_buffer_add(buf, (void *) 5) == 0,
+                "Cannot add to ring buffer");
+    fail_unless(cork_ring_buffer_add(buf, (void *) 6) == 0,
+                "Cannot add to ring buffer");
+    fail_if(cork_ring_buffer_add(buf, (void *) 7) == 0,
+            "Shouldn't be able to add to ring buffer");
+
+    fail_unless(((intptr_t) cork_ring_buffer_pop(buf)) == 3,
+                "Unexpected head of ring buffer (pop)");
+    fail_unless(((intptr_t) cork_ring_buffer_pop(buf)) == 4,
+                "Unexpected head of ring buffer (pop)");
+    fail_unless(((intptr_t) cork_ring_buffer_pop(buf)) == 5,
+                "Unexpected head of ring buffer (pop)");
+    fail_unless(((intptr_t) cork_ring_buffer_pop(buf)) == 6,
+                "Unexpected head of ring buffer (pop)");
+    fail_unless(cork_ring_buffer_pop(buf) == NULL,
+                "Shouldn't be able to pop from ring buffer");
+
+    cork_ring_buffer_free(buf);
+}
+END_TEST
 /*-----------------------------------------------------------------------
  * Testing harness
  */
@@ -78,7 +121,8 @@ test_suite()
     Suite  *s = suite_create("ring_buffer");
 
     TCase  *tc_ds = tcase_create("ring_buffer");
-    tcase_add_test(tc_ds, test_ring_buffer);
+    tcase_add_test(tc_ds, test_ring_buffer_1);
+    tcase_add_test(tc_ds, test_ring_buffer_2);
     suite_add_tcase(s, tc_ds);
 
     return s;


### PR DESCRIPTION
We need versions of `cork_ring_buffer_new()` and `cork_ring_buffer_free()`.
