### PR TITLE
Hash table initialization

### DIFF
--- a/src/libcork/ds/hash-table.c
+++ b/src/libcork/ds/hash-table.c
@@ -87,12 +87,14 @@ cork_hash_table_init(struct cork_hash_table *table,
                      cork_hash_table_hasher hasher,
                      cork_hash_table_comparator comparator)
 {
-    table->bins = NULL;
-    table->bin_count = 0;
     table->entry_count = 0;
     table->hasher = hasher;
     table->comparator = comparator;
     table->entry_mempool = cork_mempool_new(struct cork_hash_table_entry);
+    if (initial_size < CORK_HASH_TABLE_DEFAULT_INITIAL_SIZE) {
+        initial_size = CORK_HASH_TABLE_DEFAULT_INITIAL_SIZE;
+    }
+    cork_hash_table_allocate_bins(table, initial_size);
 }
 
 


### PR DESCRIPTION
All of the cork hash tables seem to be initialized to zero bins.  The default,

```
#define CORK_HASH_TABLE_DEFAULT_INITIAL_SIZE  8
```

does not appear to be used anywhere in `hash-table.c` and the `cork_hash_table_init` function which is called directly or indirectly by all of the `init` and `new` hash table functions completely ignores its `initial_size` parameter.  The only place where a size is actually set is in the `cork_hash_table_ensure_size` function.

The net result is that the first attempt at a hash entry will cause a single bin to be allocated (I think) and the effective hash mask will be 0.  A second bin will be allocated when the entry count reaches 5, etc.  While this may not matter much if the hash tables grow quickly, it will be expensive if we have many small hash tables and it makes it impossible for the coder who knows the approximate number of hash entries to expect to avoid the reallocations.
