### PR TITLE
Delete known entry from hash table

### DIFF
--- a/docs/hash-table.rst
+++ b/docs/hash-table.rst
@@ -198,6 +198,15 @@ particular use case.
    value.  This can be used, for instance, to finalize an overwritten
    key or value object.
 
+.. function:: void cork_hash_table_entry(struct cork_hash_table \*table, struct cork_hash_table_entry \*entry)
+
+   Removes *entry* from *table*.  You must ensure that *entry* refers to a
+   valid, existing entry in the hash table.  This function can be more efficient
+   than :c:func:`cork_hash_table_delete` if you've recently retrieved a hash
+   table entry using :c:func:`cork_hash_table_get_or_create` or
+   :c:func:`cork_hash_table_get_entry`, since we won't have to search for the
+   entry again.
+
 .. function:: bool cork_hash_table_delete(struct cork_hash_table \*table, const void \*key, void \*\*deleted_key, void \*\*deleted_value)
 
    Removes the entry with the given *key* from *table*.  If there isn't

--- a/include/libcork/ds/hash-table.h
+++ b/include/libcork/ds/hash-table.h
@@ -101,6 +101,10 @@ cork_hash_table_put(struct cork_hash_table *table,
                     void *key, void *value, bool *is_new,
                     void **old_key, void **old_value);
 
+CORK_API void
+cork_hash_table_delete_entry(struct cork_hash_table *table,
+                             struct cork_hash_table_entry *entry);
+
 CORK_API bool
 cork_hash_table_delete(struct cork_hash_table *table, const void *key,
                        void **deleted_key, void **deleted_value);

--- a/src/libcork/ds/hash-table.c
+++ b/src/libcork/ds/hash-table.c
@@ -392,6 +392,16 @@ cork_hash_table_put(struct cork_hash_table *table,
 }
 
 
+void
+cork_hash_table_delete_entry(struct cork_hash_table *table,
+                             struct cork_hash_table_entry *entry)
+{
+    cork_dllist_remove(&entry->siblings);
+    table->entry_count--;
+    cork_mempool_free_object(table->entry_mempool, entry);
+}
+
+
 bool
 cork_hash_table_delete(struct cork_hash_table *table, const void *key,
                        void **deleted_key, void **deleted_value)

--- a/tests/test-hash-table.c
+++ b/tests/test-hash-table.c
@@ -175,12 +175,9 @@ START_TEST(test_uint64_hash_table)
     fail_if(cork_hash_table_delete(table, &key, NULL, NULL),
             "Shouldn't be able to delete nonexistent {3=>X}");
 
-    key = 1;
-    fail_unless(cork_hash_table_delete
-                (table, &key, &v_key, &v_value),
-                "Couldn't delete {1=>2}");
-    old_key = v_key;
-    old_value = v_value;
+    old_key = entry->key;
+    old_value = entry->value;
+    cork_hash_table_delete_entry(table, entry);
     free(old_key);
     free(old_value);
 


### PR DESCRIPTION
The new `cork_hash_table_delete_entry` function lets you delete an entry from hash table more efficiently.  You pass in a `cork_hash_table_entry` instance, instead of a key value.  This means that we don't have to search through the hash table for the value to delete; the entry instance acts as a pointer to the specific entry that we want to delete.
