### PR TITLE
Unique identifiers

### DIFF
--- a/docs/basic-types.rst
+++ b/docs/basic-types.rst
@@ -22,6 +22,7 @@ addition, libcork defines some useful low-level types:
    net-addresses
    timestamps
    hash-values
+   unique-ids
 
 Integral types
 ==============

--- a/docs/unique-ids.rst
+++ b/docs/unique-ids.rst
@@ -1,0 +1,90 @@
+.. _unique-ids:
+
+******************
+Unique identifiers
+******************
+
+.. highlight:: c
+
+::
+
+  #include <libcork/core.h>
+
+
+The functions in this section let you define compile-time unique identifiers.
+These identifiers are simple C variables, and each one is guaranteed to be
+unique within the context of a single execution of your program.  They are *not*
+appropriate for use as external identifiers --- for instance, for serializing
+into long-term storage or sending via a communications channel to another
+process.
+
+
+.. type:: cork_uid
+
+   A unique identifier.
+
+
+.. macro:: cork_uid  CORK_UID_NONE
+
+   A unique identifier value that means "no identifier".  This is guaranteed to
+   be distinct from all other unique identifiers.  It is invalid to call
+   :c:func:`cork_uid_hash`, :c:func:`cork_uid_id`, or :c:func:`cork_uid_name` on
+   this identifier.
+
+
+.. macro:: cork_uid_define(SYMBOL id)
+           cork_uid_define_named(SYMBOL id, const char \*name)
+
+   You use the :c:func:`cork_uid_define` macro to define a new unique identifier
+   with the given C identifier *id*.  The ``_define`` variant also uses *id* as
+   the identifier's human-readable name; the ``_define_named`` variant let's you
+   provide a separate human-readable name.  Within the context of a single
+   execution of this program, this identifier is guaranteed to be distinct from
+   any other identifier, regardless of which library the identifiers are defined
+   in.
+
+   In the same compilation unit, you can then use the C identifier *id* to
+   retrieve the :c:type:`cork_uid` instance for this identifier.
+
+   .. note::
+
+      The unique identifier objects are declared ``static``, so they are only
+      directly visible (using the C identifier *id*) in the same compilation
+      unit as the :c:func:`cork_uid_define` call that created the identifier.
+      The resulting :c:type:`cork_uid` value, however, can be passed around the
+      rest of your code however you want.
+
+
+.. function:: bool cork_uid_equal(const cork_uid id1, const cork_uid id2)
+
+   Return whether two :c:type:`cork_uid` values refer to the same unique
+   identifier.
+
+
+.. function:: cork_hash cork_uid_hash(const cork_uid id)
+
+   Return a :ref:`hash value <hash-values>` for the given identifier.
+
+
+.. function:: const char \*cork_uid_name(const cork_uid id)
+
+   Return the name of the given unique identifier.
+
+
+Example
+=======
+
+::
+
+    #include <stdio.h>
+    #include <libcork/core.h>
+
+    cork_uid_define(test_id);
+
+    int
+    main(void)
+    {
+        cork_uid  id = test_id;
+        printf("Identifier %p has name %s\n", id, cork_uid_name(id));
+        return 0;
+    }

--- a/include/libcork/core.h
+++ b/include/libcork/core.h
@@ -19,6 +19,7 @@
 #include <libcork/core/error.h>
 #include <libcork/core/gc.h>
 #include <libcork/core/hash.h>
+#include <libcork/core/id.h>
 #include <libcork/core/mempool.h>
 #include <libcork/core/net-addresses.h>
 #include <libcork/core/timestamp.h>

--- a/include/libcork/core/id.h
+++ b/include/libcork/core/id.h
@@ -1,0 +1,35 @@
+/* -*- coding: utf-8 -*-
+ * ----------------------------------------------------------------------
+ * Copyright © 2013, RedJack, LLC.
+ * All rights reserved.
+ *
+ * Please see the COPYING file in this distribution for license details.
+ * ----------------------------------------------------------------------
+ */
+
+#ifndef LIBCORK_CORE_ID_H
+#define LIBCORK_CORE_ID_H
+
+#include <libcork/core/hash.h>
+
+
+struct cork_uid {
+    const char  *name;
+};
+
+typedef const struct cork_uid  *cork_uid;
+
+#define CORK_UID_NONE  ((cork_uid) NULL)
+
+#define cork_uid_define_named(c_name, name) \
+    static const struct cork_uid  c_name##__id = { name }; \
+    static cork_uid  c_name = &c_name##__id;
+#define cork_uid_define(c_name) \
+    cork_uid_define_named(c_name, #c_name)
+
+#define cork_uid_equal(id1, id2)  ((id1) == (id2))
+#define cork_uid_hash(id)         ((cork_hash) (uintptr_t) (id))
+#define cork_uid_name(id)         ((id)->name)
+
+
+#endif /* LIBCORK_CORE_ID_H */

--- a/tests/test-core.c
+++ b/tests/test-core.c
@@ -19,6 +19,7 @@
 #include "libcork/core/byte-order.h"
 #include "libcork/core/error.h"
 #include "libcork/core/hash.h"
+#include "libcork/core/id.h"
 #include "libcork/core/net-addresses.h"
 #include "libcork/core/timestamp.h"
 #include "libcork/core/types.h"
@@ -934,6 +935,36 @@ END_TEST
 
 
 /*-----------------------------------------------------------------------
+ * Unique identifiers
+ */
+
+START_TEST(test_uid)
+{
+    DESCRIBE_TEST;
+    cork_uid_define(test_id_01);
+    cork_uid_define(test_id_02);
+    cork_uid  id1;
+    cork_uid  id2;
+
+    fail_unless_streq("UID name", "test_id_01", cork_uid_name(test_id_01));
+    fail_unless_streq("UID name", "test_id_02", cork_uid_name(test_id_02));
+
+    id1 = test_id_01;
+    id2 = test_id_02;
+    fail_if(cork_uid_equal(id1, id2), "Unique IDs aren't unique");
+
+    id1 = test_id_01;
+    id2 = test_id_01;
+    fail_unless(cork_uid_equal(id1, id2), "Unique ID isn't equal to itself");
+
+    id1 = test_id_01;
+    id2 = CORK_UID_NONE;
+    fail_if(cork_uid_equal(id1, id2), "NULL unique ID isn't unique");
+}
+END_TEST
+
+
+/*-----------------------------------------------------------------------
  * Testing harness
  */
 
@@ -982,6 +1013,10 @@ test_suite()
     TCase  *tc_statement_expr = tcase_create("statement_expr");
     tcase_add_test(tc_statement_expr, test_statement_expr);
     suite_add_tcase(s, tc_statement_expr);
+
+    TCase  *tc_uid = tcase_create("uid");
+    tcase_add_test(tc_uid, test_uid);
+    suite_add_tcase(s, tc_uid);
 
     return s;
 }


### PR DESCRIPTION
The new `cork_unique_id` type represents a unique identifier that is visible at compile-time.  You can use these identifiers as keys for extensible points in a plugin system, for instance; the identifiers themselves will be unique within a given execution of the program, and they'll each have a name associated with them to help produce useful debug and error messages.
