### PR TITLE
Prefixing error messages

### DIFF
--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -103,6 +103,13 @@ functions that you can use to interrogate the current error condition.
    condition.  If no error occurred, the result of this function is
    undefined.
 
+You can use the :c:func:`cork_error_prefix` function to add additional context
+to the beginning of an error message.
+
+.. function:: void cork_error_prefix(const char \*format, ...)
+
+   Prepends some additional text to the current error condition.
+
 When you're done checking the current error condition, you clear it so
 that later calls to :c:func:`cork_error_occurred` and friends don't
 re-report this error.

--- a/include/libcork/core/error.h
+++ b/include/libcork/core/error.h
@@ -45,6 +45,10 @@ cork_error_set(cork_error_class error_class, cork_error_code error_code,
     CORK_ATTR_PRINTF(3,4);
 
 CORK_API void
+cork_error_prefix(const char *format, ...)
+    CORK_ATTR_PRINTF(1,2);
+
+CORK_API void
 cork_error_clear(void);
 
 

--- a/share/valgrind/libcork.supp
+++ b/share/valgrind/libcork.supp
@@ -1,24 +1,6 @@
 # Valgrind suppressions for libcork
 
 {
-   libcork/cork_error_get
-   Memcheck:Leak
-   fun:calloc
-   fun:cork_error_get
-}
-
-
-{
-   libcork/cork_error_set
-   Memcheck:Leak
-   fun:malloc
-   fun:realloc
-   fun:reallocf
-   fun:cork_buffer_append_vprintf
-   fun:cork_error_set
-}
-
-{
    libcork/cork_gc_get
    Memcheck:Leak
    fun:calloc

--- a/tests/test-core.c
+++ b/tests/test-core.c
@@ -174,10 +174,26 @@ END_TEST
  * Built-in errors
  */
 
+START_TEST(test_error_prefix)
+{
+    DESCRIBE_TEST;
+    cork_error_clear();
+    cork_error_set(CORK_BUILTIN_ERROR, CORK_SYSTEM_ERROR,
+                   "%u errors occurred", (unsigned int) 17);
+    fail_unless_streq("Error messages",
+                      "17 errors occurred",
+                      cork_error_message());
+    cork_error_prefix("The %s is aborting because ", "program");
+    fail_unless_streq("Error messages",
+                      "The program is aborting because 17 errors occurred",
+                      cork_error_message());
+    cork_error_clear();
+}
+END_TEST
+
 START_TEST(test_system_error)
 {
     DESCRIBE_TEST;
-
     /* Artificially flag a system error and make sure we can detect it */
     errno = ENOMEM;
     cork_error_clear();
@@ -984,6 +1000,7 @@ test_suite()
     suite_add_tcase(s, tc_endianness);
 
     TCase  *tc_errors = tcase_create("errors");
+    tcase_add_test(tc_errors, test_error_prefix);
     tcase_add_test(tc_errors, test_system_error);
     suite_add_tcase(s, tc_errors);
 


### PR DESCRIPTION
You can use the new `cork_error_prefix` function to prepend some additional text to an existing error message.

This patch also updates the internal implementation to clean up after itself better.  Before, we would grab a thread-local `cork_error` instance for each thread, but didn't clean up those instances.  Now, we maintain a (thread-safe) list of all of the `cork_error` instances that have been allocated, and register a (process-level) cleanup function that cleans all of them up.
