### PR TITLE
Access stdin of subprocesses

### DIFF
--- a/docs/subprocess.rst
+++ b/docs/subprocess.rst
@@ -140,6 +140,14 @@ careful orchestration, you can easily get a deadlock.  Moreover, the right
 pattern of reading and writing depends on the subprocesses that you're
 executing, so it's not something that we can handle for you automatically.)
 
+.. function:: struct cork_stream_consumer \*cork_subprocess_stdin(struct cork_subprocess \*sub)
+
+   Return a :ref:`stream consumer <stream-consumers>` that lets you write data
+   to the subprocess's stdin.  We do not buffer this data in any way; calling
+   :c:func:`cork_stream_consumer_data` immediately tries to write the given data
+   to the subprocess's stdin stream.  This can easily lead to deadlock if you do
+   not manage the subprocess's particular orchestration correctly.
+
 .. function:: bool cork_subprocess_is_finished(struct cork_subprocess \*sub)
               bool cork_subprocess_group_is_finished(struct cork_subprocess_group \*group)
 
@@ -163,10 +171,9 @@ executing, so it's not something that we can handle for you automatically.)
    course, we only do this for those subprocesses that you provided stdout or
    stderr consumers for.)
 
-   This function lets you (**TODO: eventually**) pass data into the
-   subprocesses's stdin streams, or send them signals, and handle any
-   orchestration that's necessarily to ensure that the subprocesses don't
-   deadlock.
+   This function lets you pass data into the subprocesses's stdin streams, or
+   (**TODO: eventually**) send them signals, and handle any orchestration that's
+   necessarily to ensure that the subprocesses don't deadlock.
 
    The return value indicates whether any "progress" was made.  We will return
    ``true`` if we were able to read any data from any of the subprocesses, or if

--- a/include/libcork/os/subprocess.h
+++ b/include/libcork/os/subprocess.h
@@ -141,6 +141,9 @@ cork_subprocess_new_exec(struct cork_exec *exec,
 CORK_API void
 cork_subprocess_free(struct cork_subprocess *sub);
 
+CORK_API struct cork_stream_consumer *
+cork_subprocess_stdin(struct cork_subprocess *sub);
+
 CORK_API int
 cork_subprocess_start(struct cork_subprocess *sub);
 

--- a/src/cork-test/cork-test.c
+++ b/src/cork-test/cork-test.c
@@ -163,6 +163,7 @@ static struct cork_command  c2 =
  */
 
 static const char  *sub_cwd = NULL;
+static const char  *sub_stdin = NULL;
 
 static int
 sub_options(int argc, char **argv);
@@ -178,17 +179,29 @@ static struct cork_command  sub =
 static int
 sub_options(int argc, char **argv)
 {
-    if (argc >= 2 && (streq(argv[1], "-d") || streq(argv[1], "--cwd"))) {
-        if (argc >= 3) {
-            sub_cwd = argv[2];
-            return 3;
+    int  processed = 1;
+    for (argc--, argv++; argc >= 1; argc--, argv++, processed++) {
+        if ((streq(argv[0], "-d") || streq(argv[0], "--cwd"))) {
+            if (argc >= 2) {
+                sub_cwd = argv[1];
+                argc--, argv++, processed++;
+            } else {
+                cork_command_show_help(&sub, "Missing directory for --cwd");
+                exit(EXIT_FAILURE);
+            }
+        } else if ((streq(argv[0], "-i") || streq(argv[0], "--stdin"))) {
+            if (argc >= 2) {
+                sub_stdin = argv[1];
+                argc--, argv++, processed++;
+            } else {
+                cork_command_show_help(&sub, "Missing content for --stdin");
+                exit(EXIT_FAILURE);
+            }
         } else {
-            cork_command_show_help(&sub, "Missing directory for --cwd");
-            exit(EXIT_FAILURE);
+            return processed;
         }
-    } else {
-        return 1;
     }
+    return processed;
 }
 
 static void
@@ -198,6 +211,7 @@ sub_run(int argc, char **argv)
     struct cork_exec  *exec;
     struct cork_subprocess_group  *group;
     struct cork_subprocess  *sp;
+    struct cork_stream_consumer  *stdin_consumer;
 
     if (argc == 0) {
         cork_command_show_help(&sub, "Missing command");
@@ -215,6 +229,14 @@ sub_run(int argc, char **argv)
     rp_check_exit(sp = cork_subprocess_new_exec(exec, NULL, NULL, NULL));
     cork_subprocess_group_add(group, sp);
     ri_check_exit(cork_subprocess_group_start(group));
+    stdin_consumer = cork_subprocess_stdin(sp);
+    if (sub_stdin != NULL) {
+        size_t  stdin_length = strlen(sub_stdin);
+        cork_stream_consumer_data
+            (stdin_consumer, sub_stdin, stdin_length, true);
+        cork_stream_consumer_data(stdin_consumer, "\n", 1, false);
+    }
+    cork_stream_consumer_eof(stdin_consumer);
     ri_check_exit(cork_subprocess_group_wait(group));
     cork_subprocess_group_free(group);
 }

--- a/tests/cork-test/run-sub-06.t
+++ b/tests/cork-test/run-sub-06.t
@@ -1,0 +1,3 @@
+  $ cork-test sub -i foo cat
+  cat
+  foo


### PR DESCRIPTION
You can now access the stdin stream of any `cork_subprocess` instance that you create.  Access is provided via a `cork_stream_consumer` instance; any data that you write into that stream consumer is sent to the subprocess's stdin.  We don't do any buffering, or worry in any way about the buffering of the underlying pipe — you must handle this yourself if there is any kind of complicated orchestration needed by the subprocess that you're calling.
