### PR TITLE
Subsecond string representations from Cork timestamps

### DIFF
--- a/docs/timestamps.rst
+++ b/docs/timestamps.rst
@@ -63,13 +63,35 @@ High-precision timestamps
    microseconds, or nanoseconds.
 
 
-.. function:: bool cork_timestamp_format_utc(const cork_timestamp ts, const char \*format, char \*buf, size_t size)
-              bool cork_timestamp_format_local(const cork_timestamp ts, const char \*format, char \*buf, size_t size)
+.. function:: int cork_timestamp_format_utc(const cork_timestamp ts, const char \*format, struct cork_buffer \*buf)
+              int cork_timestamp_format_local(const cork_timestamp ts, const char \*format, struct cork_buffer \*buf)
 
-   Fills in *buf* with the string representation of the given timestamp,
-   according to *fmt*, which should be a format string compatible with
-   the POSIX ``strftime`` function.  *size* must be the size (in bytes)
-   of *buf*.  If we can't format the timestamp for any reason, we return
-   ``false``.  The ``_utc`` variant assumes that *ts* represents a UTC
-   time, whereas teh ``_local`` variant assumes that it represents a
-   time in the local time zone.
+   Create the string representation of the given timestamp according to
+   *format*, appending the result to the current contents of *buf*.
+
+   The ``_utc`` variant assumes that *ts* represents a UTC time, whereas the
+   ``_local`` variant assumes that it represents a time in the local time zone.
+
+   *format* is a format string whose syntax is similar to that of the POSIX
+   ``strftime`` function.  *format* must contain arbitrary text interspersed
+   with ``%`` specifiers, which will be replaced with portions of the timestamp.
+   The following specifiers are recognized (note that this list does **not**
+   include all of the specifiers supported by ``strftime``):
+
+   ============== ====================================================
+   Specifier      Replacement
+   ============== ====================================================
+   ``%%``         A literal ``%`` character
+   ``%d``         Day of month (``01``-``31``)
+   ``%[width]f``  Fractional seconds (zero-padded, limited to ``[width]``
+                  digits)
+   ``%H``         Hour in current day (``00``-``23``)
+   ``%m``         Month (``01``-``12``)
+   ``%M``         Minute in current hour (``00``-``59``)
+   ``%s``         Number of seconds since Unix epoch
+   ``%S``         Second in current minute (``00``-``60``)
+   ``%Y``         Four-digit year (including century)
+   ============== ====================================================
+
+   If the format string is invalid, we will return an :ref:`error condition
+   <errors>`.

--- a/include/libcork/core/error.h
+++ b/include/libcork/core/error.h
@@ -62,6 +62,8 @@ cork_error_clear(void);
 enum cork_builtin_error {
     /* An error reported by the C library's errno mechanism */
     CORK_SYSTEM_ERROR,
+    /* A bad format string */
+    CORK_BAD_FORMAT,
     /* An unknown error */
     CORK_UNKNOWN_ERROR
 };

--- a/include/libcork/core/timestamp.h
+++ b/include/libcork/core/timestamp.h
@@ -15,6 +15,7 @@
 #include <libcork/core/api.h>
 #include <libcork/core/error.h>
 #include <libcork/core/types.h>
+#include <libcork/ds/buffer.h>
 
 
 typedef uint64_t  cork_timestamp;
@@ -56,20 +57,31 @@ cork_timestamp_init_now(cork_timestamp *ts);
 
 #define cork_timestamp_sec(ts)  ((uint32_t) ((ts) >> 32))
 #define cork_timestamp_gsec(ts)  ((uint32_t) ((ts) & 0xffffffff))
-#define cork_timestamp_gsec_to_units(ts, denom) \
-    (((uint64_t) (ts) & 0xffffffff) * (denom) >> 32)
+
+CORK_ATTR_UNUSED
+static inline uint64_t
+cork_timestamp_gsec_to_units(const cork_timestamp ts, uint64_t denom)
+{
+    uint64_t  half = ((uint64_t) 1 << 31) / denom;
+    uint64_t  gsec = cork_timestamp_gsec(ts);
+    gsec += half;
+    gsec *= denom;
+    gsec >>= 32;
+    return gsec;
+}
+
 #define cork_timestamp_msec(ts)  cork_timestamp_gsec_to_units(ts, 1000)
 #define cork_timestamp_usec(ts)  cork_timestamp_gsec_to_units(ts, 1000000)
 #define cork_timestamp_nsec(ts)  cork_timestamp_gsec_to_units(ts, 1000000000)
 
 
-CORK_API bool
+CORK_API int
 cork_timestamp_format_utc(const cork_timestamp ts, const char *format,
-                          char *buf, size_t size);
+                          struct cork_buffer *dest);
 
-CORK_API bool
+CORK_API int
 cork_timestamp_format_local(const cork_timestamp ts, const char *format,
-                            char *buf, size_t size);
+                            struct cork_buffer *dest);
 
 
 #endif /* LIBCORK_CORE_TIMESTAMP_H */

--- a/src/libcork/core/timestamp.c
+++ b/src/libcork/core/timestamp.c
@@ -8,11 +8,13 @@
  * ----------------------------------------------------------------------
  */
 
+#include <string.h>
 #include <time.h>
 #include <sys/time.h>
 
 #include "libcork/core/timestamp.h"
 #include "libcork/core/types.h"
+#include "libcork/helpers/errors.h"
 
 void
 cork_timestamp_init_now(cork_timestamp *ts)
@@ -23,29 +25,139 @@ cork_timestamp_init_now(cork_timestamp *ts)
 }
 
 
-bool
-cork_timestamp_format_utc(const cork_timestamp ts,
-                          const char *format,
-                          char *buf, size_t size)
-{
-    time_t  clock;
-    struct tm  tm;
+#define is_digit(ch)  ((ch) >= '0' && (ch) <= '9')
 
-    clock = cork_timestamp_sec(ts);
-    gmtime_r(&clock, &tm);
-    return strftime(buf, size, format, &tm) > 0;
+static uint64_t
+power_of_10(unsigned int width)
+{
+    uint64_t  accumulator = 10;
+    uint64_t  result = 1;
+    while (width != 0) {
+        if ((width % 2) == 1) {
+            result *= accumulator;
+            width--;
+        }
+        accumulator *= accumulator;
+        width /= 2;
+    }
+    return result;
 }
 
+static int
+append_fractional(const cork_timestamp ts, unsigned int width,
+                  struct cork_buffer *dest)
+{
+    if (CORK_UNLIKELY(width == 0 || width > 9)) {
+        cork_error_set
+            (CORK_BUILTIN_ERROR, CORK_BAD_FORMAT,
+             "Invalid width %u for fractional cork_timestamp", width);
+        return -1;
+    } else {
+        uint64_t  denom = power_of_10(width);
+        uint64_t  frac = cork_timestamp_gsec_to_units(ts, denom);
+        cork_buffer_append_printf(dest, "%0*" PRIu64, width, frac);
+        return 0;
+    }
+}
 
-bool
-cork_timestamp_format_local(const cork_timestamp ts,
-                            const char *format,
-                            char *buf, size_t size)
+static int
+cork_timestamp_format_parts(const cork_timestamp ts, struct tm *tm,
+                            const char *format, struct cork_buffer *dest)
+{
+    const char  *next_percent;
+
+    while ((next_percent = strchr(format, '%')) != NULL) {
+        const char  *spec = next_percent + 1;
+        unsigned int  width = 0;
+
+        /* First append any text in between the previous format specifier and
+         * this one. */
+        cork_buffer_append(dest, format, next_percent - format);
+
+        /* Then parse the format specifier */
+        while (is_digit(*spec)) {
+            width *= 10;
+            width += (*spec++ - '0');
+        }
+
+        switch (*spec) {
+            case '\0':
+                cork_error_set
+                    (CORK_BUILTIN_ERROR, CORK_BAD_FORMAT,
+                     "Trailing %% at end of cork_timestamp format string");
+                return -1;
+
+            case '%':
+                cork_buffer_append(dest, "%", 1);
+                break;
+
+            case 'Y':
+                cork_buffer_append_printf(dest, "%04d", tm->tm_year + 1900);
+                break;
+
+            case 'm':
+                cork_buffer_append_printf(dest, "%02d", tm->tm_mon + 1);
+                break;
+
+            case 'd':
+                cork_buffer_append_printf(dest, "%02d", tm->tm_mday);
+                break;
+
+            case 'H':
+                cork_buffer_append_printf(dest, "%02d", tm->tm_hour);
+                break;
+
+            case 'M':
+                cork_buffer_append_printf(dest, "%02d", tm->tm_min);
+                break;
+
+            case 'S':
+                cork_buffer_append_printf(dest, "%02d", tm->tm_sec);
+                break;
+
+            case 's':
+                cork_buffer_append_printf
+                    (dest, "%" PRIu32, cork_timestamp_sec(ts));
+                break;
+
+            case 'f':
+                rii_check(append_fractional(ts, width, dest));
+                break;
+
+            default:
+                cork_error_set
+                    (CORK_BUILTIN_ERROR, CORK_BAD_FORMAT,
+                     "Unknown cork_timestamp format specifier %%%c", *spec);
+                return -1;
+        }
+
+        format = spec + 1;
+    }
+
+    /* When we fall through, there is some additional content after the final
+     * format specifier. */
+    cork_buffer_append_string(dest, format);
+    return 0;
+}
+
+int
+cork_timestamp_format_utc(const cork_timestamp ts, const char *format,
+                          struct cork_buffer *dest)
 {
     time_t  clock;
     struct tm  tm;
+    clock = cork_timestamp_sec(ts);
+    gmtime_r(&clock, &tm);
+    return cork_timestamp_format_parts(ts, &tm, format, dest);
+}
 
+int
+cork_timestamp_format_local(const cork_timestamp ts, const char *format,
+                            struct cork_buffer *dest)
+{
+    time_t  clock;
+    struct tm  tm;
     clock = cork_timestamp_sec(ts);
     localtime_r(&clock, &tm);
-    return strftime(buf, size, format, &tm) > 0;
+    return cork_timestamp_format_parts(ts, &tm, format, dest);
 }


### PR DESCRIPTION
cork_timestamp_format_utc() and cork_timestamp_format_local() produce time strings with 1 second resolution.  Internally, time is maintained with gamma second resolution (1 part in 2^32).  It would be useful to provide support for higher resolution times.

At present, this requires appending the fractional representation to the string value returned by the above functions and may require "munging" the string if it contains an explicit time zone component.  This could be subsumed into the basic functionality in several ways:
- Proliferate the number of function signatures to provide functions for each desired degree of precision.
- Extend the strftime format to include an explicit fractional second notation that indicated the precision desired, e.g %f (for fraction - lower case f is the first letter that is not already used in the strftime format)  %f (or %1f) would display the time truncated to 0.1 second, %2f to 0.01 sec, etc.
- Add an explicit fractional units parameter to the functions.  This could indicate the desired precision in decmal digits with 0 producing the current whole second values, 1 giving 0.1 second resolution, etc.  This could be accompanied by an enum declaration in the .h file to provide symbolic definitions.
  - If this approach is used, it might be useful to explicitly pass the indicator for time zone representation (UTC, local, or arbitrary) to the functions, as well allowing the format string to specify only the format down to the whole second.  Note that the general practice for time values is to store them relative to the UTC beginning of the epoch.  There are many cases where you want to display time in a time zone that is neither UTC (available with gmtime) nor the the time zone of the conversion (available with localtime).  Having the ability to do this is desirable, even though it is not explicitly supported in the Unix time conversion functions.
