### PR TITLE
Simpler error API

### DIFF
--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -10,41 +10,40 @@ Error reporting
 
   #include <libcork/core.h>
 
-This section defines an API for reporting error conditions.  It's
-loosely modeled on glib's *GError* API.
+This section defines an API for reporting error conditions.  It's loosely
+modeled on the POSIX ``errno`` mechanism.
 
-The standard POSIX approach for reporting errors is to return an integer
-status code, and to store error codes into the ``errno`` global
-variable.  This approach has a couple of drawbacks.  The first is that
-you have to ensure that ``errno`` is placed in thread-local storage, so
-that separate threads have their own error condition variables.  The
-second, and in our mind more important, is that the set of error codes
-is fixed and platform-dependent.  It's difficult to add new error codes
-to represent application-level error conditions.
+The standard POSIX approach for reporting errors is to return an integer status
+code, and to store error codes into the ``errno`` global variable.  This
+approach has a couple of drawbacks.  The first is that you --- or really, your C
+library --- has to ensure that ``errno`` is placed in thread-local storage, so
+that separate threads have their own error condition variables.  The second, and
+in our mind more important, is that the set of error codes is fixed and
+platform-dependent.  It's difficult to add new error codes to represent
+application-level error conditions.
 
-The libcork error API is a way around this.  Errors are represented by a
-tuple of an *error class* and an *error code*, along with a
-human-readable string description of the error.  Error classes represent
-broad classes of errors, and usually correspond to a library or to an
-important group of related functions within a library.  An error class
-is represented by a hash of some string identifying the library or group
-of functions.  This “hash of a string” approach makes it easy to define
-new error classes, without needing any centralized mechanism for
-assigning IDs to the various classes.  An error code is a simple
-integer, and only needs to be unique within a particular error class.
-This means that each error class is free to define its error codes
-however it wishes (usually via an ``enum`` type), without having to
-worry about them clashing with the codes of any other class.
+The libcork error API is a way around this.  Like standard POSIX-conforming
+functions, you return an integer status code from any function that might need
+to report an error to its caller.  The status return code is simple: ``0``
+indicates success, ``-1`` indicates failure.
+
+When an error occurs, you can use the functions in this section to get more
+information about the error: an *error code*, and human-readable string
+description of the error.  The POSIX ``errno`` values, while hard to extend, are
+perfectly well-defined for most platforms; therefore, any ``errno`` value
+supported by your system's C library is a valid libcork error code.  To support
+new application-specific error codes, an error code can also be the hash of some
+string describing the error.  This “hash of a string” approach makes it easy to
+define new error codes without needing any centralized mechanism for assigning
+IDs to the various codes.  Moreover, it's very unlikely that a hashed error code
+will conflict with some existing POSIX ``errno`` value, or with any other hashed
+error codes.
 
 .. note::
 
    We correctly maintain a separate error condition for each thread in
    the current process.  This is all hidden by the functions in this
    section; it's safe to call them from multiple threads simultaneously.
-
-.. macro:: CORK_ERROR_NONE
-
-   A special error class that signals that no error occurred.
 
 
 Calling a function that can return an error
@@ -68,21 +67,6 @@ possible, if the function needs to signal more than a simple “success”
 or “failure”; in that case, you'll need to check the function's
 documentation for details.)
 
-If you want to know specifics about the error, we provide several
-accessor functions:
-
-.. function:: bool cork_error_occurred(void)
-              cork_error_class cork_error_get_class(void)
-              cork_error_code cork_error_get_code(void)
-              const char \*cork_error_message(void)
-
-   Returns information about the current error condition.  This
-   information is maintained in thread-local storage, so it is safe
-   to call these functions from multiple threads simultaneously.  Note
-   that you often won't need to call ``cork_error_occurred``, since
-   you'll usually be able to detect error conditions by checking a
-   function's return value.
-
 If you want to know specifics about the error, there are several
 functions that you can use to interrogate the current error condition.
 
@@ -90,12 +74,10 @@ functions that you can use to interrogate the current error condition.
 
    Returns whether an error has occurred.
 
-.. function:: cork_error_class cork_error_get_class(void)
-              cork_error_code cork_error_get_code(void)
+.. function:: cork_error cork_error_code(void)
 
-   Returns the class and code of the current error condition.  If no
-   error has occurred, the error class will be
-   :c:macro:`CORK_ERROR_NONE`, and the code will be ``0``.
+   Returns the error code of the current error condition.  If no error has
+   occurred, the result will be :c:macro:`CORK_ERROR_NONE`.
 
 .. function:: const char \*cork_error_message(void)
 
@@ -103,10 +85,12 @@ functions that you can use to interrogate the current error condition.
    condition.  If no error occurred, the result of this function is
    undefined.
 
-You can use the :c:func:`cork_error_prefix` function to add additional context
-to the beginning of an error message.
+You can use the ``cork_error_prefix`` family of functions to add additional
+context to the beginning of an error message.
 
-.. function:: void cork_error_prefix(const char \*format, ...)
+.. function:: void cork_error_prefix_printf(const char \*format, ...)
+              void cork_error_prefix_string(const char \*string)
+              void cork_error_prefix_vprintf(const char \*format, va_list args)
 
    Prepends some additional text to the current error condition.
 
@@ -141,23 +125,24 @@ codes if there are other possible results besides a simple “success” and
 “failure”.)
 
 If your function results in an error, you need to fill in the current
-error condition using the ``cork_error_set`` function:
+error condition using the ``cork_error_set`` family of functions:
 
-.. function:: void cork_error_set(cork_error_class eclass, cork_error_code ecode, const char \*format, ...)
+.. function:: void cork_error_set_printf(cork_error ecode, const char \*format, ...)
+              void cork_error_set_string(cork_error ecode, const char \*string)
+              void cork_error_set_vprintf(cork_error ecode, const char \*format, va_list args)
 
    Fills in the current error condition.  The error condition is defined
-   by the error class *eclass*, the error code *ecode*.  The
-   human-readable description is constructed from *format* and any
-   additional parameters.
+   by the error code *ecode*.  The human-readable description is constructed
+   from *string*, or from *format* and any additional parameters, depending on
+   which variant you use.
 
-As an example, the :ref:`IP address <net-addresses>` parsing functions
-fill in ``CORK_NET_ADDRESS_PARSE_ERROR`` error conditions when you try
-to parse a malformed address::
+As an example, the :ref:`IP address <net-addresses>` parsing functions fill in
+:c:macro:`CORK_PARSE_ERROR` error conditions when you try to parse a malformed
+address::
 
   const char  *str = /* the string that's being parsed */;
-  cork_error_set
-      (CORK_NET_ADDRESS_ERROR, CORK_NET_ADDRESS_PARSE_ERROR,
-       "Invalid IP address: %s", str);
+  cork_error_set_printf
+      (CORK_PARSE_ERROR, "Invalid IP address: %s", str);
 
 If a particular kind of error can be raised in several places
 throughout your code, it can be useful to define a helper function for
@@ -166,9 +151,8 @@ filling in the current error condition::
   static void
   cork_ip_address_parse_error(const char *version, const char *str)
   {
-      cork_error_set
-          (CORK_NET_ADDRESS_ERROR, CORK_NET_ADDRESS_PARSE_ERROR,
-           "Invalid %s address: %s", version, str);
+      cork_error_set_printf
+          (CORK_PARSE_ERROR, "Invalid %s address: %s", version, str);
   }
 
 
@@ -334,8 +318,9 @@ Calling POSIX functions
 
 The :c:func:`cork_system_error_set` function automatically translates a POSIX
 error (specified in the standard ``errno`` variable) into a libcork error
-condition.  We also define several helper macros for calling a POSIX function
-and automatically checking its result.
+condition (which will be reported by :c:func:`cork_error_occurred` and friends).
+We also define several helper macros for calling a POSIX function and
+automatically checking its result.
 
 ::
 
@@ -386,88 +371,100 @@ and automatically checking its result.
    the current scope's ``error`` label.
 
 
-Defining a new error class
---------------------------
+Defining new error codes
+------------------------
 
-If none of the built-in error classes and codes suffice for an error
-condition that you need to report, you'll have to define our own error
-class.
+If none of the built-in error codes suffice for an error condition that you need
+to report, you'll have to define our own.  As mentioned above, each libcork
+error code is either a predefined POSIX ``errno`` value, or a hash some of
+string identifying a custom error condition.
 
-Error classes and codes
-~~~~~~~~~~~~~~~~~~~~~~~
+Typically, you will create a macro in one of your public header files, whose
+value will be your new custom error code.  If this is the case, you can use the
+macro name itself to create the hash value for the error code.  This is what we
+do for the non-POSIX builtin errors; for instance, the value of the
+:c:macro:`CORK_PARSE_ERROR` error code macro is the hash of the string
+``CORK_PARSE_ERROR``.
 
-The first step is to decide on some string that will represent your
-error class.  This string must be unique across all error classes, so it
-should include (at least) some representation of the library name.  In
-libcork itself, we always use the name of the header file that the error
-class is defined in.  (This limits us to one error class per header, but
-that's not a deal-breaker.)  Thus, the :c:macro:`CORK_NET_ADDRESS_ERROR`
-error class is represented by the string
-``"libcork/core/net-addresses.h"``.
+Given this string, you can produce the error code's hash value using the
+:ref:`cork-hash <cork-hash>` command that's installed with libcork::
 
-Given this string, you can produce the error class's hash value using
-the :ref:`cork-hash <cork-hash>` command that's installed with libcork::
+  $ cork-hash CORK_PARSE_ERROR
+  0x95dfd3c8
 
-  $ cork-hash "libcork/core/net-addresses.h"
-  0x1f76fedf
+It's incredibly unlikely that the hash value for your new error code will
+conflict with any other custom hash-based error codes, or with any predefined
+POSIX ``errno`` values.
 
-The next step is to define the error codes within the class.  This is
-best done by creating an ``enum`` class.  Taken together, we have the
-following definitions for the error conditions in the
-:ref:`net-addresses` module::
+With your macro name and hash value ready, defining the new error code is
+simple::
 
-  /* hash of "libcork/core/net-addresses.h" */
-  #define CORK_NET_ADDRESS_ERROR  0x1f76fedf
+  #define CORK_PARSE_ERROR  0x95dfd3c8
 
-  enum cork_net_address_error {
-      /* A parse error while parsing a network address. */
-      CORK_NET_ADDRESS_PARSE_ERROR
-  };
+You should also provide a helper macro that makes it easier to report new
+instances of this error condition::
 
-This gives us a constant for the error class, and a set of constants for
-each error code within the class, all of which start with a standard
-namespace prefix (``CORK_NET_ADDRESS_``).
+  #define cork_parse_error(...) \
+      cork_error_set_printf(CORK_PARSE_ERROR, __VA_ARGS__)
 
-.. type:: uint32_t  cork_error_class
+.. type:: uint32_t  cork_error
 
-   An identifier for a class of error conditions.  Should be the hash of
-   a unique string describing the error class.
-
-.. type:: unsigned int  cork_error_code
-
-   An identifier for a particular type of error within an error class.
-   The particular values within an error class should be defined using
-   an ``enum`` type.
+   An identifier for a particular error condition.  This will either be a
+   predefined POSIX ``errno`` value, or the hash of a unique string describing
+   the error condition.
 
 With your error class and code defined, you can fill in error instances
-using :c:func:`cork_error_set()`.
+using :c:func:`cork_error_set_printf` and friends.
 
 
 Builtin errors
 --------------
 
-There are a few basic, builtin errors that you can use if no others are
-applicable.  In almost all cases, you'll want to define a more specific
-error class and code instead.
+In addition to all of the predefined POSIX ``errno`` values, we also provide
+error codes for a handful of common error conditions.  You should feel free to
+use these in your libraries and applications, instead of creating custom error
+codes, if they apply.
 
-.. macro:: CORK_BUILTIN_ERROR
-           CORK_SYSTEM_ERROR
-           CORK_UNKNOWN_ERROR
+.. macro:: CORK_ERROR_NONE
 
-   The error class and codes used for the error conditions described in
-   this section.
+   A special error code that signals that no error occurred.
+
+.. macro:: CORK_PARSE_ERROR
+
+   The provided input violates the rules of the language grammar or file format
+   (or anything else, really) that you're trying to parse.
+
+   .. function:: void cork_parse_error(const char *format*, ...)
+
+.. macro:: CORK_REDEFINED
+           CORK_UNDEFINED
+
+   Useful when you have a container type that must ensure that there is only one
+   entry for any given key.
+
+   .. function:: void cork_redefined(const char *format*, ...)
+                 void cork_undefined(const char *format*, ...)
+
+.. macro:: CORK_UNKNOWN_ERROR
+
+   Some error occurred, but we don't have any other information about the error.
+
+   .. function:: void cork_unknown_error(void)
+
+      The error description will include the name of the current function.
+
+
+We also provide some helper functions for setting these built-in errors:
 
 .. function:: void cork_system_error_set(void)
+              void cork_system_error_set_explicit(int err)
 
-   Fills in the current error condition with information from the C
-   library's ``errno`` variable.  The human-readable description of the
-   error will be obtained from the standard ``strerror`` function.
+   Fills in the current libcork error condition with information from a POSIX
+   ``errno`` value.  The human-readable description of the error will be
+   obtained from the standard ``strerror`` function.  With the ``_explicit``
+   variant, you provide the ``errno`` value directly; for the other variant, we
+   get the error code from the C library's ``errno`` variable.
 
-.. function:: void cork_unknown_error_set(void)
-
-   Fills in the current error condition to indicate that there was some
-   unknown error.  The error description will include the name of the
-   current function.
 
 .. function:: void cork_abort(const char \*fmt, ...)
 

--- a/include/libcork/core/error.h
+++ b/include/libcork/core/error.h
@@ -1,16 +1,17 @@
 /* -*- coding: utf-8 -*-
  * ----------------------------------------------------------------------
- * Copyright © 2011, RedJack, LLC.
+ * Copyright © 2011-2013, RedJack, LLC.
  * All rights reserved.
  *
- * Please see the COPYING file in this distribution for license
- * details.
+ * Please see the COPYING file in this distribution for license details.
  * ----------------------------------------------------------------------
  */
 
 #ifndef LIBCORK_CORE_ERROR_H
 #define LIBCORK_CORE_ERROR_H
 
+#include <errno.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -19,54 +20,75 @@
 #include <libcork/core/types.h>
 
 
-/* Should be a hash of a string representing the error class. */
-typedef uint32_t  cork_error_class;
+/* Should be a hash of a string representing the error code. */
+typedef uint32_t  cork_error;
 
-/* An error class that represents “no error”. */
-#define CORK_ERROR_NONE  ((cork_error_class) 0)
-
-typedef unsigned int  cork_error_code;
+/* An error code that represents “no error”. */
+#define CORK_ERROR_NONE  ((cork_error) 0)
 
 CORK_API bool
 cork_error_occurred(void);
 
-CORK_API cork_error_class
-cork_error_get_class(void);
-
-CORK_API cork_error_code
-cork_error_get_code(void);
+CORK_API cork_error
+cork_error_code(void);
 
 CORK_API const char *
 cork_error_message(void);
 
-CORK_API void
-cork_error_set(cork_error_class error_class, cork_error_code error_code,
-               const char *format, ...)
-    CORK_ATTR_PRINTF(3,4);
-
-CORK_API void
-cork_error_prefix(const char *format, ...)
-    CORK_ATTR_PRINTF(1,2);
 
 CORK_API void
 cork_error_clear(void);
+
+CORK_API void
+cork_error_set_printf(cork_error code, const char *format, ...)
+    CORK_ATTR_PRINTF(2,3);
+
+CORK_API void
+cork_error_set_string(cork_error code, const char *str);
+
+CORK_API void
+cork_error_set_vprintf(cork_error code, const char *format, va_list args)
+    CORK_ATTR_PRINTF(2,0);
+
+CORK_API void
+cork_error_prefix_printf(const char *format, ...)
+    CORK_ATTR_PRINTF(1,2);
+
+CORK_API void
+cork_error_prefix_string(const char *str);
+
+CORK_API void
+cork_error_prefix_vprintf(const char *format, va_list arg)
+    CORK_ATTR_PRINTF(1,0);
+
+
+/* deprecated */
+CORK_API void
+cork_error_set(uint32_t error_class, unsigned int error_code,
+               const char *format, ...)
+    CORK_ATTR_PRINTF(3,4);
+
+/* deprecated */
+CORK_API void
+cork_error_prefix(const char *format, ...)
+    CORK_ATTR_PRINTF(1,2);
 
 
 /*-----------------------------------------------------------------------
  * Built-in errors
  */
 
-/* hash of "libcork/core/error.h" */
-#define CORK_BUILTIN_ERROR  0xd178dde5
+#define CORK_PARSE_ERROR               0x95dfd3c8
+#define CORK_REDEFINED                 0x171629cb
+#define CORK_UNDEFINED                 0xedc3d7d9
+#define CORK_UNKNOWN_ERROR             0x8cb0880d
 
-enum cork_builtin_error {
-    /* An error reported by the C library's errno mechanism */
-    CORK_SYSTEM_ERROR,
-    /* A bad format string */
-    CORK_BAD_FORMAT,
-    /* An unknown error */
-    CORK_UNKNOWN_ERROR
-};
+#define cork_parse_error(...) \
+    cork_error_set_printf(CORK_PARSE_ERROR, __VA_ARGS__)
+#define cork_redefined(...) \
+    cork_error_set_printf(CORK_REDEFINED, __VA_ARGS__)
+#define cork_undefined(...) \
+    cork_error_set_printf(CORK_UNDEFINED, __VA_ARGS__)
 
 CORK_API void
 cork_system_error_set(void);

--- a/include/libcork/core/net-addresses.h
+++ b/include/libcork/core/net-addresses.h
@@ -1,10 +1,9 @@
 /* -*- coding: utf-8 -*-
  * ----------------------------------------------------------------------
- * Copyright © 2011, RedJack, LLC.
+ * Copyright © 2011-2013, RedJack, LLC.
  * All rights reserved.
  *
- * Please see the COPYING file in this distribution for license
- * details.
+ * Please see the COPYING file in this distribution for license details.
  * ----------------------------------------------------------------------
  */
 
@@ -17,19 +16,6 @@
 #include <libcork/core/api.h>
 #include <libcork/core/error.h>
 #include <libcork/core/types.h>
-
-
-/*-----------------------------------------------------------------------
- * Error handling
- */
-
-/* hash of "libcork/core/net-addresses.h" */
-#define CORK_NET_ADDRESS_ERROR  0x1f76fedf
-
-enum cork_net_address_error {
-    /* A parse error while parsing a network address. */
-    CORK_NET_ADDRESS_PARSE_ERROR
-};
 
 
 /*-----------------------------------------------------------------------

--- a/src/libcork/core/error.c
+++ b/src/libcork/core/error.c
@@ -1,10 +1,9 @@
 /* -*- coding: utf-8 -*-
  * ----------------------------------------------------------------------
- * Copyright © 2011, RedJack, LLC.
+ * Copyright © 2011-2013, RedJack, LLC.
  * All rights reserved.
  *
- * Please see the COPYING file in this distribution for license
- * details.
+ * Please see the COPYING file in this distribution for license details.
  * ----------------------------------------------------------------------
  */
 
@@ -26,8 +25,7 @@
  */
 
 struct cork_error {
-    cork_error_class  error_class;
-    cork_error_code  error_code;
+    cork_error  code;
     struct cork_buffer  *message;
     struct cork_buffer  *other;
     struct cork_buffer  buf1;
@@ -39,7 +37,7 @@ static struct cork_error *
 cork_error_new(void)
 {
     struct cork_error  *error = cork_new(struct cork_error);
-    error->error_class = CORK_ERROR_NONE;
+    error->code = CORK_ERROR_NONE;
     cork_buffer_init(&error->buf1);
     cork_buffer_init(&error->buf2);
     error->message = &error->buf1;
@@ -108,21 +106,14 @@ bool
 cork_error_occurred(void)
 {
     struct cork_error  *error = cork_error_get();
-    return error->error_class != CORK_ERROR_NONE;
+    return error->code != CORK_ERROR_NONE;
 }
 
-cork_error_class
-cork_error_get_class(void)
+cork_error
+cork_error_code(void)
 {
     struct cork_error  *error = cork_error_get();
-    return error->error_class;
-}
-
-cork_error_code
-cork_error_get_code(void)
-{
-    struct cork_error  *error = cork_error_get();
-    return error->error_code;
+    return error->code;
 }
 
 const char *
@@ -133,20 +124,42 @@ cork_error_message(void)
 }
 
 void
-cork_error_set(cork_error_class error_class, cork_error_code error_code,
-               const char *format, ...)
+cork_error_clear(void)
+{
+    struct cork_error  *error = cork_error_get();
+    error->code = CORK_ERROR_NONE;
+    cork_buffer_clear(error->message);
+}
+
+void
+cork_error_set_printf(cork_error code, const char *format, ...)
 {
     va_list  args;
     struct cork_error  *error = cork_error_get();
-    error->error_class = error_class;
-    error->error_code = error_code;
+    error->code = code;
     va_start(args, format);
     cork_buffer_vprintf(error->message, format, args);
     va_end(args);
 }
 
 void
-cork_error_prefix(const char *format, ...)
+cork_error_set_string(cork_error code, const char *str)
+{
+    struct cork_error  *error = cork_error_get();
+    error->code = code;
+    cork_buffer_set_string(error->message, str);
+}
+
+void
+cork_error_set_vprintf(cork_error code, const char *format, va_list args)
+{
+    struct cork_error  *error = cork_error_get();
+    error->code = code;
+    cork_buffer_vprintf(error->message, format, args);
+}
+
+void
+cork_error_prefix_printf(const char *format, ...)
 {
     va_list  args;
     struct cork_error  *error = cork_error_get();
@@ -161,29 +174,73 @@ cork_error_prefix(const char *format, ...)
 }
 
 void
-cork_error_clear(void)
+cork_error_prefix_string(const char *str)
 {
     struct cork_error  *error = cork_error_get();
-    error->error_class = CORK_ERROR_NONE;
-    error->error_code = 0;
+    struct cork_buffer  *temp;
+    cork_buffer_set_string(error->other, str);
+    cork_buffer_append_copy(error->other, error->message);
+    temp = error->other;
+    error->other = error->message;
+    error->message = temp;
 }
+
+void
+cork_error_prefix_vprintf(const char *format, va_list args)
+{
+    struct cork_error  *error = cork_error_get();
+    struct cork_buffer  *temp;
+    cork_buffer_vprintf(error->other, format, args);
+    cork_buffer_append_copy(error->other, error->message);
+    temp = error->other;
+    error->other = error->message;
+    error->message = temp;
+}
+
+
+/*-----------------------------------------------------------------------
+ * Deprecated
+ */
+
+void
+cork_error_set(uint32_t error_class, unsigned int error_code,
+               const char *format, ...)
+{
+    /* Create a fallback error code that's most likely not very useful. */
+    va_list  args;
+    va_start(args, format);
+    cork_error_set_vprintf(error_class + error_code, format, args);
+    va_end(args);
+}
+
+void
+cork_error_prefix(const char *format, ...)
+{
+    va_list  args;
+    va_start(args, format);
+    cork_error_prefix_vprintf(format, args);
+    va_end(args);
+}
+
+
+/*-----------------------------------------------------------------------
+ * Built-in errors
+ */
 
 void
 cork_system_error_set_explicit(int err)
 {
-    cork_error_set(CORK_BUILTIN_ERROR, CORK_SYSTEM_ERROR, "%s", strerror(err));
+    cork_error_set_string(err, strerror(err));
 }
 
 void
 cork_system_error_set(void)
 {
-    cork_system_error_set_explicit(errno);
+    cork_error_set_string(errno, strerror(errno));
 }
 
 void
 cork_unknown_error_set_(const char *location)
 {
-    cork_error_set
-        (CORK_BUILTIN_ERROR, CORK_UNKNOWN_ERROR,
-         "Unknown error in %s", location);
+    cork_error_set_printf(CORK_UNKNOWN_ERROR, "Unknown error in %s", location);
 }

--- a/src/libcork/core/ip-address.c
+++ b/src/libcork/core/ip-address.c
@@ -1,10 +1,9 @@
 /* -*- coding: utf-8 -*-
  * ----------------------------------------------------------------------
- * Copyright © 2011, RedJack, LLC.
+ * Copyright © 2011-2013, RedJack, LLC.
  * All rights reserved.
  *
- * Please see the COPYING file in this distribution for license
- * details.
+ * Please see the COPYING file in this distribution for license details.
  * ----------------------------------------------------------------------
  */
 
@@ -99,9 +98,7 @@ cork_ipv4_parse(struct cork_ipv4 *addr, const char *str)
 
 parse_error:
     DEBUG("parse error\n");
-    cork_error_set
-        (CORK_NET_ADDRESS_ERROR, CORK_NET_ADDRESS_PARSE_ERROR,
-         "Invalid IPv4 address: \"%s\"", str);
+    cork_parse_error("Invalid IPv4 address: \"%s\"", str);
     return NULL;
 }
 
@@ -331,9 +328,7 @@ cork_ipv6_init(struct cork_ipv6 *addr, const char *str)
 
 parse_error:
     DEBUG("parse error\n");
-    cork_error_set
-        (CORK_NET_ADDRESS_ERROR, CORK_NET_ADDRESS_PARSE_ERROR,
-         "Invalid IPv6 address: \"%s\"", str);
+    cork_parse_error("Invalid IPv6 address: \"%s\"", str);
     return -1;
 }
 
@@ -492,9 +487,7 @@ cork_ip_init(struct cork_ip *addr, const char *str)
     }
 
     /* Parse error for both address types */
-    cork_error_set
-        (CORK_NET_ADDRESS_ERROR, CORK_NET_ADDRESS_PARSE_ERROR,
-         "Invalid IP address: \"%s\"", str);
+    cork_parse_error("Invalid IP address: \"%s\"", str);
     return -1;
 }
 

--- a/src/libcork/core/timestamp.c
+++ b/src/libcork/core/timestamp.c
@@ -1,10 +1,9 @@
 /* -*- coding: utf-8 -*-
  * ----------------------------------------------------------------------
- * Copyright © 2011, RedJack, LLC.
+ * Copyright © 2011-2013, RedJack, LLC.
  * All rights reserved.
  *
- * Please see the COPYING file in this distribution for license
- * details.
+ * Please see the COPYING file in this distribution for license details.
  * ----------------------------------------------------------------------
  */
 
@@ -48,8 +47,8 @@ append_fractional(const cork_timestamp ts, unsigned int width,
                   struct cork_buffer *dest)
 {
     if (CORK_UNLIKELY(width == 0 || width > 9)) {
-        cork_error_set
-            (CORK_BUILTIN_ERROR, CORK_BAD_FORMAT,
+        cork_error_set_printf
+            (EINVAL,
              "Invalid width %u for fractional cork_timestamp", width);
         return -1;
     } else {
@@ -82,8 +81,8 @@ cork_timestamp_format_parts(const cork_timestamp ts, struct tm *tm,
 
         switch (*spec) {
             case '\0':
-                cork_error_set
-                    (CORK_BUILTIN_ERROR, CORK_BAD_FORMAT,
+                cork_error_set_string
+                    (EINVAL,
                      "Trailing %% at end of cork_timestamp format string");
                 return -1;
 
@@ -125,8 +124,8 @@ cork_timestamp_format_parts(const cork_timestamp ts, struct tm *tm,
                 break;
 
             default:
-                cork_error_set
-                    (CORK_BUILTIN_ERROR, CORK_BAD_FORMAT,
+                cork_error_set_printf
+                    (EINVAL,
                      "Unknown cork_timestamp format specifier %%%c", *spec);
                 return -1;
         }

--- a/src/libcork/posix/files.c
+++ b/src/libcork/posix/files.c
@@ -478,9 +478,9 @@ cork_path_list_find_file(const struct cork_path_list *list,
         }
     }
 
-    cork_error_set
-        (CORK_BUILTIN_ERROR, CORK_SYSTEM_ERROR,
-         "%s not found in %s", rel_path, cork_path_list_to_string(list));
+    cork_error_set_printf
+        (ENOENT, "%s not found in %s",
+         rel_path, cork_path_list_to_string(list));
     return NULL;
 
 error:
@@ -753,9 +753,7 @@ cork_path_home(void)
 {
     const char  *path = cork_env_get(NULL, "HOME");
     if (empty_string(path)) {
-        cork_error_set
-            (CORK_BUILTIN_ERROR, CORK_SYSTEM_ERROR,
-             "Cannot determine home directory");
+        cork_undefined("Cannot determine home directory");
         return NULL;
     } else {
         return cork_path_new(path);
@@ -866,9 +864,7 @@ cork_path_user_runtime_path(void)
      * no default given by the spec. */
     var = cork_env_get(NULL, "XDG_RUNTIME_DIR");
     if (empty_string(var)) {
-        cork_error_set
-            (CORK_BUILTIN_ERROR, CORK_SYSTEM_ERROR,
-             "Cannot determine user-specific runtime directory");
+        cork_undefined("Cannot determine user-specific runtime directory");
         return NULL;
     } else {
         return cork_path_new(var);

--- a/src/libcork/pthreads/thread.c
+++ b/src/libcork/pthreads/thread.c
@@ -3,8 +3,7 @@
  * Copyright © 2013, RedJack, LLC.
  * All rights reserved.
  *
- * Please see the COPYING file in this distribution for license
- * details.
+ * Please see the COPYING file in this distribution for license details.
  * ----------------------------------------------------------------------
  */
 
@@ -15,6 +14,7 @@
 #include "libcork/core/allocator.h"
 #include "libcork/core/error.h"
 #include "libcork/core/types.h"
+#include "libcork/ds/buffer.h"
 #include "libcork/threads/basics.h"
 
 
@@ -29,9 +29,8 @@ struct cork_thread {
     cork_thread_id  id;
     pthread_t  thread_id;
     struct cork_thread_body  *body;
-    cork_error_class  error_class;
-    cork_error_code  error_code;
-    const char  *error_message;
+    cork_error  error_code;
+    struct cork_buffer  error_message;
     bool  started;
     bool  joined;
 };
@@ -76,8 +75,8 @@ cork_thread_new(const char *name, struct cork_thread_body *body)
     self->name = cork_strdup(name);
     self->id = cork_uint_atomic_add(&last_thread_descriptor, 1);
     self->body = body;
-    self->error_class = CORK_ERROR_NONE;
-    self->error_message = NULL;
+    self->error_code = CORK_ERROR_NONE;
+    cork_buffer_init(&self->error_message);
     self->started = false;
     self->joined = false;
     return self;
@@ -88,9 +87,7 @@ cork_thread_free_private(struct cork_thread *self)
 {
     cork_strfree(self->name);
     cork_thread_body_free(self->body);
-    if (self->error_message != NULL) {
-        cork_strfree(self->error_message);
-    }
+    cork_buffer_done(&self->error_message);
     free(self);
 }
 
@@ -129,13 +126,11 @@ cork_thread_pthread_run(void *vself)
      * cork_thread_join. */
     if (CORK_UNLIKELY(rc != 0)) {
         if (CORK_LIKELY(cork_error_occurred())) {
-            self->error_class = cork_error_get_class();
-            self->error_code = cork_error_get_code();
-            self->error_message = cork_strdup(cork_error_message());
+            self->error_code = cork_error_code();
+            cork_buffer_set_string(&self->error_message, cork_error_message());
         } else {
-            self->error_class = CORK_BUILTIN_ERROR;
             self->error_code = CORK_UNKNOWN_ERROR;
-            self->error_message = cork_strdup("Unknown error");
+            cork_buffer_set_string(&self->error_message, "Unknown error");
         }
     }
 
@@ -175,10 +170,10 @@ cork_thread_join(struct cork_thread *self)
         return -1;
     }
 
-    if (CORK_UNLIKELY(self->error_class != CORK_ERROR_NONE)) {
-        cork_error_set(self->error_class, self->error_code,
-                       "Error from thread %s: %s",
-                       self->name, self->error_message);
+    if (CORK_UNLIKELY(self->error_code != CORK_ERROR_NONE)) {
+        cork_error_set_printf
+            (self->error_code, "Error from thread %s: %s",
+             self->name, (char *) self->error_message.buf);
         cork_thread_free_private(self);
         return -1;
     }

--- a/tests/test-core.c
+++ b/tests/test-core.c
@@ -179,8 +179,8 @@ START_TEST(test_error_prefix)
 {
     DESCRIBE_TEST;
     cork_error_clear();
-    cork_error_set(CORK_BUILTIN_ERROR, CORK_SYSTEM_ERROR,
-                   "%u errors occurred", (unsigned int) 17);
+    cork_error_set_printf
+        (CORK_UNKNOWN_ERROR, "%u errors occurred", (unsigned int) 17);
     fail_unless_streq("Error messages",
                       "17 errors occurred",
                       cork_error_message());
@@ -199,9 +199,7 @@ START_TEST(test_system_error)
     errno = ENOMEM;
     cork_error_clear();
     cork_system_error_set();
-    fail_unless(cork_error_get_class() == CORK_BUILTIN_ERROR,
-                "Expected a built-in error");
-    fail_unless(cork_error_get_code() == CORK_SYSTEM_ERROR,
+    fail_unless(cork_error_code() == ENOMEM,
                 "Expected a system error");
     printf("Got error: %s\n", cork_error_message());
     cork_error_clear();


### PR DESCRIPTION
This patch simplifies the libcork error API.  Before, we followed glib's [GError](https://developer.gnome.org/glib/2.37/glib-Error-Reporting.html) API, where there were separate “classes” and “codes” for each custom error condition.  The class was meant to identify the library that the custom error belongs to, and the code only had to be unique within each class.  GError creates error class values at runtime, using its GQuark mechanism.  We used hashes of unique strings as error classes.  Error codes were then defined using a simple enum.

This is more cumbersome than it needs to be.  With this new patch, we no longer have error classes at all.  Individual error codes are now hash values, usually of the name of the error code's macro.  (I.e., the value of the `CORK_PARSE_ERROR` error code is the hash of the string `"CORK_PARSE_ERROR"`.)  This new design also lets us use the existing, predefined, well-known POSIX `errno` values as error codes directly, which makes it easier to integrate code that uses the POSIX error reporting facilities and libcork's error API.
