### PR TITLE
Fixed iteration order in hash tables

### DIFF
--- a/include/libcork/core/callbacks.h
+++ b/include/libcork/core/callbacks.h
@@ -11,6 +11,9 @@
 #define LIBCORK_CORE_CALLBACKS_H
 
 
+#include <libcork/core/hash.h>
+
+
 typedef int
 (*cork_copy_f)(void *user_data, void *dest, const void *src);
 
@@ -19,6 +22,12 @@ typedef void
 
 typedef void
 (*cork_free_f)(void *value);
+
+typedef cork_hash
+(*cork_hash_f)(void *user_data, const void *value);
+
+typedef bool
+(*cork_equals_f)(void *user_data, const void *value1, const void *value2);
 
 typedef void
 (*cork_init_f)(void *user_data, void *value);

--- a/include/libcork/ds/hash-table.h
+++ b/include/libcork/ds/hash-table.h
@@ -1,10 +1,9 @@
 /* -*- coding: utf-8 -*-
  * ----------------------------------------------------------------------
- * Copyright © 2011-2012, RedJack, LLC.
+ * Copyright © 2011-2013, RedJack, LLC.
  * All rights reserved.
  *
- * Please see the COPYING file in this distribution for license
- * details.
+ * Please see the COPYING file in this distribution for license details.
  * ----------------------------------------------------------------------
  */
 
@@ -12,6 +11,7 @@
 #define LIBCORK_DS_HASH_TABLE_H
 
 #include <libcork/core/api.h>
+#include <libcork/core/callbacks.h>
 #include <libcork/core/hash.h>
 #include <libcork/core/mempool.h>
 #include <libcork/core/types.h>
@@ -22,56 +22,31 @@
  * Hash tables
  */
 
-typedef cork_hash
-(*cork_hash_table_hasher)(const void *key);
-
-typedef bool
-(*cork_hash_table_comparator)(const void *key1, const void *key2);
-
 struct cork_hash_table_entry {
-    /* The hash of this entry's key. */
     cork_hash  hash;
-    /* This entry's key */
     void  *key;
-    /* This entry's value */
     void  *value;
-    /* A link to the other entries in the same hash bucket. */
-    struct cork_dllist_item  siblings;
 };
 
 
-struct cork_hash_table {
-    /* The current array of bins in the hash table. */
-    struct cork_dllist  *bins;
-    /* The number of bins in the hash table. */
-    size_t  bin_count;
-    /* The number of entries in the hash table. */
-    size_t  entry_count;
-    /* A hashing function. */
-    cork_hash_table_hasher  hasher;
-    /* A comparator function. */
-    cork_hash_table_comparator  comparator;
-    /* A memory pool for the hash table entries */
-    struct cork_mempool  *entry_mempool;
-};
-
-
-CORK_API void
-cork_hash_table_init(struct cork_hash_table *table,
-                     size_t initial_size,
-                     cork_hash_table_hasher hasher,
-                     cork_hash_table_comparator comparator);
+struct cork_hash_table;
 
 CORK_API struct cork_hash_table *
-cork_hash_table_new(size_t initial_size,
-                    cork_hash_table_hasher hasher,
-                    cork_hash_table_comparator comparator);
-
-CORK_API void
-cork_hash_table_done(struct cork_hash_table *table);
+cork_hash_table_new(size_t initial_size, unsigned int flags);
 
 CORK_API void
 cork_hash_table_free(struct cork_hash_table *table);
+
+
+CORK_API void
+cork_hash_table_set_user_data(struct cork_hash_table *table,
+                              void *user_data, cork_free_f free_user_data);
+
+CORK_API void
+cork_hash_table_set_equals(struct cork_hash_table *table, cork_equals_f equals);
+
+CORK_API void
+cork_hash_table_set_hash(struct cork_hash_table *table, cork_hash_f hash);
 
 
 CORK_API void
@@ -82,7 +57,8 @@ CORK_API void
 cork_hash_table_ensure_size(struct cork_hash_table *table,
                             size_t desired_count);
 
-#define cork_hash_table_size(table) ((table)->entry_count)
+CORK_API size_t
+cork_hash_table_size(const struct cork_hash_table *table);
 
 
 CORK_API void *
@@ -121,20 +97,16 @@ enum cork_hash_table_map_result {
 };
 
 typedef enum cork_hash_table_map_result
-(*cork_hash_table_mapper)(struct cork_hash_table_entry *entry,
-                          void *user_data);
+(*cork_hash_table_map_f)(void *user_data, struct cork_hash_table_entry *entry);
 
 CORK_API void
-cork_hash_table_map(struct cork_hash_table *table,
-                    cork_hash_table_mapper mapper, void *user_data);
+cork_hash_table_map(struct cork_hash_table *table, void *user_data,
+                    cork_hash_table_map_f mapper);
 
 
 struct cork_hash_table_iterator {
     struct cork_hash_table  *table;
-    /* The index of the current bin */
-    size_t  bin_index;
-    /* The current element within the bin */
-    struct cork_dllist_item  *curr;
+    void  *priv;
 };
 
 CORK_API void
@@ -149,18 +121,11 @@ cork_hash_table_iterator_next(struct cork_hash_table_iterator *iterator);
  * Built-in key types
  */
 
-CORK_API void
-cork_string_hash_table_init(struct cork_hash_table *table, size_t initial_size);
+CORK_API struct cork_hash_table *
+cork_string_hash_table_new(size_t initial_size, unsigned int flags);
 
 CORK_API struct cork_hash_table *
-cork_string_hash_table_new(size_t initial_size);
-
-CORK_API void
-cork_pointer_hash_table_init(struct cork_hash_table *table,
-                              size_t initial_size);
-
-CORK_API struct cork_hash_table *
-cork_pointer_hash_table_new(size_t initial_size);
+cork_pointer_hash_table_new(size_t initial_size, unsigned int flags);
 
 
 #endif /* LIBCORK_DS_HASH_TABLE_H */

--- a/src/libcork/posix/env.c
+++ b/src/libcork/posix/env.c
@@ -58,7 +58,7 @@ cork_env_var_free(struct cork_env_var *var)
 
 
 struct cork_env {
-    struct cork_hash_table  variables;
+    struct cork_hash_table  *variables;
     struct cork_buffer  buffer;
 };
 
@@ -66,7 +66,7 @@ struct cork_env *
 cork_env_new(void)
 {
     struct cork_env  *env = cork_new(struct cork_env);
-    cork_string_hash_table_init(&env->variables, 0);
+    env->variables = cork_string_hash_table_new(0, 0);
     cork_buffer_init(&env->buffer);
     return env;
 }
@@ -81,7 +81,7 @@ cork_env_add_internal(struct cork_env *env, const char *name, const char *value)
         void  *old_var;
 
         cork_hash_table_put
-            (&env->variables, (void *) var->name, var, NULL, NULL, &old_var);
+            (env->variables, (void *) var->name, var, NULL, NULL, &old_var);
 
         if (old_var != NULL) {
             cork_env_var_free(old_var);
@@ -116,7 +116,7 @@ cork_env_clone_current(void)
 
 
 static enum cork_hash_table_map_result
-cork_env_free_vars(struct cork_hash_table_entry *entry, void *user_data)
+cork_env_free_vars(void *user_data, struct cork_hash_table_entry *entry)
 {
     struct cork_env_var  *var = entry->value;
     cork_env_var_free(var);
@@ -126,8 +126,8 @@ cork_env_free_vars(struct cork_hash_table_entry *entry, void *user_data)
 void
 cork_env_free(struct cork_env *env)
 {
-    cork_hash_table_map(&env->variables, cork_env_free_vars, NULL);
-    cork_hash_table_done(&env->variables);
+    cork_hash_table_map(env->variables, NULL, cork_env_free_vars);
+    cork_hash_table_free(env->variables);
     cork_buffer_done(&env->buffer);
     free(env);
 }
@@ -139,7 +139,7 @@ cork_env_get(struct cork_env *env, const char *name)
         return getenv(name);
     } else {
         struct cork_env_var  *var =
-            cork_hash_table_get(&env->variables, (void *) name);
+            cork_hash_table_get(env->variables, (void *) name);
         return (var == NULL)? NULL: var->value;
     }
 }
@@ -175,7 +175,7 @@ cork_env_remove(struct cork_env *env, const char *name)
         unsetenv(name);
     } else {
         void  *old_var;
-        cork_hash_table_delete(&env->variables, (void *) name, NULL, &old_var);
+        cork_hash_table_delete(env->variables, (void *) name, NULL, &old_var);
         if (old_var != NULL) {
             cork_env_var_free(old_var);
         }
@@ -184,7 +184,7 @@ cork_env_remove(struct cork_env *env, const char *name)
 
 
 static enum cork_hash_table_map_result
-cork_env_set_vars(struct cork_hash_table_entry *entry, void *user_data)
+cork_env_set_vars(void *user_data, struct cork_hash_table_entry *entry)
 {
     struct cork_env_var  *var = entry->value;
     setenv(var->name, var->value, false);
@@ -211,5 +211,5 @@ void
 cork_env_replace_current(struct cork_env *env)
 {
     clearenv();
-    cork_hash_table_map(&env->variables, cork_env_set_vars, NULL);
+    cork_hash_table_map(env->variables, NULL, cork_env_set_vars);
 }


### PR DESCRIPTION
When iterating through a hash table (whether explicitly via a `cork_hash_table_iterator`, or autoatically via `cork_hash_table_map`), we now guarantee that the elements will be processed in the same order that they were added to the hash table.

To support this, we need an additional doubly-linked list to keep track of the insertion order.  This requires adding fields to the `cork_hash_table` type.  So, I'm taking this opportunity to make that type completely opaque.  That means that this will be a backwards-incompatible change; all code that still embeds a copy of `cork_hash_table`, and uses `cork_hash_table_init` to initialize it, will need to be updated to use `cork_hash_table_new` instead.

Finally, at the same time, I've made a couple of other backwards-incompatible changes to make the hash table API more consistent with our current best practices.  First, the hashing and comparison functions now take in a `user_data` parameter, just like any other callback.  Second, the signature of the `cork_hash_table_map`, and its `map` callback, have been reordered so that `user_data` comes first.
