### PR TITLE
Additional doubly-linked list functions

### DIFF
--- a/src/libcork/ds/dllist.c
+++ b/src/libcork/ds/dllist.c
@@ -1,18 +1,21 @@
 /* -*- coding: utf-8 -*-
  * ----------------------------------------------------------------------
- * Copyright © 2011, RedJack, LLC.
+ * Copyright © 2011-2014, RedJack, LLC.
  * All rights reserved.
  *
- * Please see the COPYING file in this distribution for license
- * details.
+ * Please see the COPYING file in this distribution for license details.
  * ----------------------------------------------------------------------
  */
 
+#include "libcork/core/api.h"
 #include "libcork/core/types.h"
 #include "libcork/ds/dllist.h"
 
 
-void
+/* Include a linkable (but deprecated) version of this to maintain ABI
+ * compatibility. */
+#undef cork_dllist_init
+CORK_API void
 cork_dllist_init(struct cork_dllist *list)
 {
     list->head.next = &list->head;
@@ -24,14 +27,26 @@ void
 cork_dllist_map(struct cork_dllist *list,
                 cork_dllist_map_func func, void *user_data)
 {
-    struct cork_dllist_item  *curr = cork_dllist_start(list);
-    while (!cork_dllist_is_end(list, curr)) {
-        /* Extract the next pointer now, just in case func frees the
-         * list item. */
-        struct cork_dllist_item  *next = curr->next;
+    struct cork_dllist_item  *curr;
+    struct cork_dllist_item  *next;
+    cork_dllist_foreach_void(list, curr, next) {
         func(curr, user_data);
-        curr = next;
     }
+}
+
+int
+cork_dllist_visit(struct cork_dllist *list, void *ud,
+                  cork_dllist_visit_f *visit)
+{
+    struct cork_dllist_item  *curr;
+    struct cork_dllist_item  *next;
+    cork_dllist_foreach_void(list, curr, next) {
+        int  rc = visit(ud, curr);
+        if (rc != 0) {
+            return rc;
+        }
+    }
+    return 0;
 }
 
 
@@ -40,8 +55,8 @@ cork_dllist_size(const struct cork_dllist *list)
 {
     size_t  size = 0;
     struct cork_dllist_item  *curr;
-    for (curr = cork_dllist_end(list);
-         !cork_dllist_is_start(list, curr); curr = curr->prev) {
+    struct cork_dllist_item  *next;
+    cork_dllist_foreach_void(list, curr, next) {
         size++;
     }
     return size;

--- a/tests/test-dllist.c
+++ b/tests/test-dllist.c
@@ -1,10 +1,9 @@
 /* -*- coding: utf-8 -*-
  * ----------------------------------------------------------------------
- * Copyright © 2011, RedJack, LLC.
+ * Copyright © 2011-2014, RedJack, LLC.
  * All rights reserved.
  *
- * Please see the COPYING file in this distribution for license
- * details.
+ * Please see the COPYING file in this distribution for license details.
  * ----------------------------------------------------------------------
  */
 
@@ -15,7 +14,10 @@
 #include <check.h>
 
 #include "libcork/core/types.h"
+#include "libcork/ds/buffer.h"
 #include "libcork/ds/dllist.h"
+
+#include "helpers.h"
 
 
 /*-----------------------------------------------------------------------
@@ -27,51 +29,87 @@ struct int64_item {
     struct cork_dllist_item  element;
 };
 
-static void
-int64_sum(struct cork_dllist_item *element, void *user_data)
+static int
+int64_sum(void *user_data, struct cork_dllist_item *element)
 {
     int64_t  *sum = user_data;
     struct int64_item  *item =
         cork_container_of(element, struct int64_item, element);
     *sum += item->value;
+    return 0;
+}
+
+static void
+check_int64_list(struct cork_dllist *list, const char *expected)
+{
+    bool  first = true;
+    struct cork_buffer  buf = CORK_BUFFER_INIT();
+    struct cork_dllist_item  *curr;
+    struct cork_dllist_item  *next;
+    struct int64_item  *item;
+    cork_buffer_append_literal(&buf, "");
+    cork_dllist_foreach(list, curr, next, struct int64_item, item, element) {
+        if (first) {
+            first = false;
+        } else {
+            cork_buffer_append_literal(&buf, ",");
+        }
+        cork_buffer_append_printf(&buf, "%" PRId64, item->value);
+    }
+    fail_unless_streq("List contents", expected, buf.buf);
+    cork_buffer_done(&buf);
 }
 
 START_TEST(test_dllist)
 {
     struct cork_dllist  list;
-    cork_dllist_init(&list);
-
-    fail_unless(cork_dllist_size(&list) == 0,
-                "Unexpected size of list: got %zu, expected 0",
-                cork_dllist_size(&list));
-
-    fail_unless(cork_dllist_is_empty(&list),
-                "Expected empty list");
-
+    struct cork_dllist_item  *curr;
+    struct cork_dllist_item  *next;
+    struct int64_item  *item;
     struct int64_item  item1;
     struct int64_item  item2;
     struct int64_item  item3;
+    int64_t  sum;
+
+    cork_dllist_init(&list);
+    fail_unless(cork_dllist_size(&list) == 0,
+                "Unexpected size of list: got %zu, expected 0",
+                cork_dllist_size(&list));
+    fail_unless(cork_dllist_is_empty(&list),
+                "Expected empty list");
+    check_int64_list(&list, "");
 
     item1.value = 1;
     cork_dllist_add(&list, &item1.element);
     fail_unless(cork_dllist_size(&list) == 1,
                 "Unexpected size of list: got %zu, expected 1",
                 cork_dllist_size(&list));
+    check_int64_list(&list, "1");
 
     item2.value = 2;
     cork_dllist_add(&list, &item2.element);
     fail_unless(cork_dllist_size(&list) == 2,
                 "Unexpected size of list: got %zu, expected 2",
                 cork_dllist_size(&list));
+    check_int64_list(&list, "1,2");
 
     item3.value = 3;
     cork_dllist_add(&list, &item3.element);
     fail_unless(cork_dllist_size(&list) == 3,
                 "Unexpected size of list: got %zu, expected 3",
                 cork_dllist_size(&list));
+    check_int64_list(&list, "1,2,3");
 
-    int64_t  sum = 0;
-    cork_dllist_map(&list, int64_sum, &sum);
+    sum = 0;
+    fail_if(cork_dllist_visit(&list, &sum, int64_sum));
+    fail_unless(sum == 6,
+                "Unexpected sum, got %ld, expected 6",
+                (long) sum);
+
+    sum = 0;
+    cork_dllist_foreach(&list, curr, next, struct int64_item, item, element) {
+        sum += item->value;
+    }
     fail_unless(sum == 6,
                 "Unexpected sum, got %ld, expected 6",
                 (long) sum);
@@ -80,6 +118,46 @@ START_TEST(test_dllist)
     fail_unless(cork_dllist_size(&list) == 2,
                 "Unexpected size of list: got %zu, expected 2",
                 cork_dllist_size(&list));
+}
+END_TEST
+
+START_TEST(test_dllist_append)
+{
+    struct cork_dllist  list1 = CORK_DLLIST_INIT(list1);
+    struct cork_dllist  list2 = CORK_DLLIST_INIT(list2);
+    struct int64_item  item1;
+    struct int64_item  item2;
+    struct int64_item  item3;
+    struct int64_item  item4;
+    struct int64_item  item5;
+    struct int64_item  item6;
+    struct int64_item  item7;
+
+    item1.value = 1;
+    cork_dllist_add_to_head(&list1, &item1.element);
+    check_int64_list(&list1, "1");
+
+    item2.value = 2;
+    cork_dllist_add_to_head(&list1, &item2.element);
+    check_int64_list(&list1, "2,1");
+
+    item3.value = 3;
+    cork_dllist_add_to_tail(&list1, &item3.element);
+    check_int64_list(&list1, "2,1,3");
+
+    item4.value = 4;
+    cork_dllist_add_to_tail(&list2, &item4.element);
+    item5.value = 5;
+    cork_dllist_add_to_tail(&list2, &item5.element);
+    cork_dllist_add_list_to_head(&list1, &list2);
+    check_int64_list(&list1, "4,5,2,1,3");
+
+    item6.value = 6;
+    cork_dllist_add_to_tail(&list2, &item6.element);
+    item7.value = 7;
+    cork_dllist_add_to_tail(&list2, &item7.element);
+    cork_dllist_add_list_to_tail(&list1, &list2);
+    check_int64_list(&list1, "4,5,2,1,3,6,7");
 }
 END_TEST
 
@@ -95,6 +173,7 @@ test_suite()
 
     TCase  *tc_ds = tcase_create("dllist");
     tcase_add_test(tc_ds, test_dllist);
+    tcase_add_test(tc_ds, test_dllist_append);
     suite_add_tcase(s, tc_ds);
 
     return s;


### PR DESCRIPTION
This patch adds a few new functions for working with doubly-linked lists.  The functions for adding single elements to a list have more descriptive names, and there are now functions for moving an entire list of elements into some other list (in constant time).

Additionally, the function for mapping through a list has replaced with a function for “visiting” each element.  This is mainly to make the function signatures more consistent with our other callback-based functionality — you can abort the iteration with a non-zero result code, and the `user_data` parameter is first.

Lastly, there are now helper macros for iterating through a list yourself, rather than using a visitor callback.  See the documentation or test case on how to use it.
