### PR TITLE
Include thread linker flags in pkgconfig file

### DIFF
--- a/src/libcork.pc.in
+++ b/src/libcork.pc.in
@@ -9,5 +9,5 @@ Name: libcork
 Description: A simple, easily embeddable cross-platform C library
 Version: @VERSION@
 URL: http://github.com/redjack/libcork
-Libs: -L${libdir} -lcork
+Libs: -L${libdir} -lcork @CMAKE_THREAD_LIBS_INIT@
 Cflags: -I${includedir}


### PR DESCRIPTION
On Debian, it looks like we need to tell any library that links with libcork to also link with the threading library that libcork was configured to use.  We can pass that information along using the pkgconfig file.
