### PR TITLE
Remove cork_thread_body

### DIFF
--- a/docs/subprocess.rst
+++ b/docs/subprocess.rst
@@ -34,13 +34,13 @@ Creating subprocesses
 There are several functions that you can use to create and execute child
 processes.
 
-.. function:: struct cork_subprocess \*cork_subprocess_new(struct cork_thread_body \*body, struct cork_stream_consumer \*stdout, struct cork_stream_consumer \*stderr, int \*exit_code)
+.. function:: struct cork_subprocess \*cork_subprocess_new(void \*user_data, cork_free_f free_user_data, cork_run_f run, struct cork_stream_consumer \*stdout, struct cork_stream_consumer \*stderr, int \*exit_code)
               struct cork_subprocess \*cork_subprocess_new_exec(struct cork_exec \*exec, struct cork_stream_consumer \*stdout, struct cork_stream_consumer \*stderr, int \*exit_code)
 
    Create a new subprocess specification.  The first variant will execute the
-   given *body* callback object in the subprocess.  The second variant will
-   execute a new program in the subprocess; the details of the program to
-   execute are given by a :c:type:`cork_exec` specification object.
+   given *run* function in the subprocess.  The second variant will execute a
+   new program in the subprocess; the details of the program to execute are
+   given by a :c:type:`cork_exec` specification object.
 
    For both of these functions, you can collect the data that the subprocess
    writes to its stdout and stderr streams by passing in :ref:`stream consumer
@@ -55,8 +55,7 @@ processes.
    finishes.  For :c:func:`cork_subprocess_new_exec`, the exit code is the value
    passed to the builtin ``exit`` function, or the value returned from the
    subprocess's ``main`` function.  For :c:func:`cork_subprocess_new`, the exit
-   code is the value returned from the thread body's
-   :c:member:`~cork_thread_body.run` method.
+   code is the value returned from the thread body's *run* function.
 
 
 You can also create *groups* of subprocesses.  This lets you start up several

--- a/include/libcork/core/callbacks.h
+++ b/include/libcork/core/callbacks.h
@@ -1,6 +1,6 @@
 /* -*- coding: utf-8 -*-
  * ----------------------------------------------------------------------
- * Copyright © 2013, RedJack, LLC.
+ * Copyright © 2013-2014, RedJack, LLC.
  * All rights reserved.
  *
  * Please see the COPYING file in this distribution for license details.
@@ -38,6 +38,9 @@ typedef void
 
 typedef void *
 (*cork_new_f)(void *user_data);
+
+typedef int
+(*cork_run_f)(void *user_data);
 
 
 #endif /* LIBCORK_CORE_CALLBACKS_H */

--- a/include/libcork/os/subprocess.h
+++ b/include/libcork/os/subprocess.h
@@ -1,10 +1,9 @@
 /* -*- coding: utf-8 -*-
  * ----------------------------------------------------------------------
- * Copyright © 2012-2013, RedJack, LLC.
+ * Copyright © 2012-2014, RedJack, LLC.
  * All rights reserved.
  *
- * Please see the COPYING file in this distribution for license
- * details.
+ * Please see the COPYING file in this distribution for license details.
  * ----------------------------------------------------------------------
  */
 
@@ -14,6 +13,7 @@
 #include <stdarg.h>
 
 #include <libcork/core/api.h>
+#include <libcork/core/callbacks.h>
 #include <libcork/core/types.h>
 #include <libcork/ds/stream.h>
 #include <libcork/threads/basics.h>
@@ -126,7 +126,8 @@ struct cork_subprocess;
 
 /* Takes control of body */
 CORK_API struct cork_subprocess *
-cork_subprocess_new(struct cork_thread_body *body,
+cork_subprocess_new(void *user_data, cork_free_f free_user_data,
+                    cork_run_f run,
                     struct cork_stream_consumer *stdout_consumer,
                     struct cork_stream_consumer *stderr_consumer,
                     int *exit_code);

--- a/include/libcork/threads/basics.h
+++ b/include/libcork/threads/basics.h
@@ -1,10 +1,9 @@
 /* -*- coding: utf-8 -*-
  * ----------------------------------------------------------------------
- * Copyright © 2012, RedJack, LLC.
+ * Copyright © 2012-2014, RedJack, LLC.
  * All rights reserved.
  *
- * Please see the COPYING file in this distribution for license
- * details.
+ * Please see the COPYING file in this distribution for license details.
  * ----------------------------------------------------------------------
  */
 
@@ -15,6 +14,7 @@
 
 #include <libcork/core/api.h>
 #include <libcork/core/attributes.h>
+#include <libcork/core/callbacks.h>
 #include <libcork/threads/atomics.h>
 
 
@@ -33,22 +33,6 @@ cork_current_thread_get_id(void);
 
 
 /*-----------------------------------------------------------------------
- * Main functions
- */
-
-struct cork_thread_body {
-    int
-    (*run)(struct cork_thread_body *self);
-
-    void
-    (*free)(struct cork_thread_body *self);
-};
-
-#define cork_thread_body_run(tb)  ((tb)->run((tb)))
-#define cork_thread_body_free(tb)  ((tb)->free((tb)))
-
-
-/*-----------------------------------------------------------------------
  * Threads
  */
 
@@ -60,7 +44,9 @@ CORK_API struct cork_thread *
 cork_current_thread_get(void);
 
 CORK_API struct cork_thread *
-cork_thread_new(const char *name, struct cork_thread_body *body);
+cork_thread_new(const char *name,
+                void *user_data, cork_free_f free_user_data,
+                cork_run_f run);
 
 /* Thread must not have been started yet. */
 CORK_API void

--- a/src/libcork/posix/subprocess.c
+++ b/src/libcork/posix/subprocess.c
@@ -312,13 +312,16 @@ struct cork_subprocess {
     struct cork_write_pipe  stdin_pipe;
     struct cork_read_pipe  stdout_pipe;
     struct cork_read_pipe  stderr_pipe;
-    struct cork_thread_body  *body;
+    void  *user_data;
+    cork_free_f  free_user_data;
+    cork_run_f  run;
     int  *exit_code;
     char  buf[BUF_SIZE];
 };
 
 struct cork_subprocess *
-cork_subprocess_new(struct cork_thread_body *body,
+cork_subprocess_new(void *user_data, cork_free_f free_user_data,
+                    cork_run_f run,
                     struct cork_stream_consumer *stdout_consumer,
                     struct cork_stream_consumer *stderr_consumer,
                     int *exit_code)
@@ -328,7 +331,9 @@ cork_subprocess_new(struct cork_thread_body *body,
     cork_read_pipe_init(&self->stdout_pipe, stdout_consumer);
     cork_read_pipe_init(&self->stderr_pipe, stderr_consumer);
     self->pid = 0;
-    self->body = body;
+    self->user_data = user_data;
+    self->free_user_data = free_user_data;
+    self->run = run;
     self->exit_code = exit_code;
     return self;
 }
@@ -336,7 +341,7 @@ cork_subprocess_new(struct cork_thread_body *body,
 void
 cork_subprocess_free(struct cork_subprocess *self)
 {
-    cork_thread_body_free(self->body);
+    cork_free_user_data(self);
     cork_write_pipe_done(&self->stdin_pipe);
     cork_read_pipe_done(&self->stdout_pipe);
     cork_read_pipe_done(&self->stderr_pipe);
@@ -354,36 +359,18 @@ cork_subprocess_stdin(struct cork_subprocess *self)
  * Executing another program
  */
 
-struct cork_exec_body {
-    struct cork_thread_body  parent;
-    struct cork_exec  *exec;
-};
-
 static int
-cork_exec__run(struct cork_thread_body *vself)
+cork_exec__run(void *vself)
 {
-    struct cork_exec_body  *self =
-        cork_container_of(vself, struct cork_exec_body, parent);
-    return cork_exec_run(self->exec);
+    struct cork_exec  *exec = vself;
+    return cork_exec_run(exec);
 }
 
 static void
-cork_exec__free(struct cork_thread_body *vself)
+cork_exec__free(void *vself)
 {
-    struct cork_exec_body  *self =
-        cork_container_of(vself, struct cork_exec_body, parent);
-    cork_exec_free(self->exec);
-    free(self);
-}
-
-static struct cork_thread_body *
-cork_exec_body_new(struct cork_exec *exec)
-{
-    struct cork_exec_body  *self = cork_new(struct cork_exec_body);
-    self->parent.run = cork_exec__run;
-    self->parent.free = cork_exec__free;
-    self->exec = exec;
-    return &self->parent;
+    struct cork_exec  *exec = vself;
+    cork_exec_free(exec);
 }
 
 struct cork_subprocess *
@@ -392,8 +379,10 @@ cork_subprocess_new_exec(struct cork_exec *exec,
                          struct cork_stream_consumer *err,
                          int *exit_code)
 {
-    struct cork_thread_body  *body = cork_exec_body_new(exec);
-    return cork_subprocess_new(body, out, err, exit_code);
+    return cork_subprocess_new
+        (exec, cork_exec__free,
+         cork_exec__run,
+         out, err, exit_code);
 }
 
 
@@ -446,8 +435,8 @@ cork_subprocess_start(struct cork_subprocess *self)
             _exit(EXIT_FAILURE);
         }
 
-        /* Run the subprocess's body */
-        rc = cork_thread_body_run(self->body);
+        /* Run the subprocess */
+        rc = self->run(self->user_data);
         if (CORK_LIKELY(rc == 0)) {
             _exit(EXIT_SUCCESS);
         } else {


### PR DESCRIPTION
Part of a larger effort to move away from embedded structs for these kinds of OO-like types.  (We want to be able to make the types completely opaque, so that we can add to them at will without breaking ABI compatibility.)
