### PR TITLE
Don't clear buffer when consuming stream

### DIFF
--- a/src/libcork/ds/buffer.c
+++ b/src/libcork/ds/buffer.c
@@ -440,11 +440,6 @@ cork_buffer_stream_consumer_data(struct cork_stream_consumer *consumer,
 {
     struct cork_buffer__stream_consumer  *bconsumer = cork_container_of
         (consumer, struct cork_buffer__stream_consumer, consumer);
-
-    if (is_first_chunk) {
-        cork_buffer_clear(bconsumer->buffer);
-    }
-
     cork_buffer_append(bconsumer->buffer, buf, size);
     return 0;
 }

--- a/tests/test-buffer.c
+++ b/tests/test-buffer.c
@@ -192,14 +192,15 @@ START_TEST(test_buffer_stream)
     static char  SRC2[] = "efg";
     size_t  SRC2_LEN = 3;
 
-    static char  EXPECTED[] = "abcdefg";
-    static size_t  EXPECTED_SIZE = 7;
+    static char  EXPECTED[] = "000abcdefg";
+    static size_t  EXPECTED_SIZE = 10;
 
     struct cork_buffer  buffer1;
     struct cork_buffer  buffer2;
     struct cork_stream_consumer  *consumer;
 
     cork_buffer_init(&buffer1);
+    cork_buffer_append_string(&buffer1, "000");
     fail_if_error(consumer =
                   cork_buffer_to_stream_consumer(&buffer1));
 


### PR DESCRIPTION
The `cork_buffer_to_stream_consumer` function claims that the resulting stream consumer will append to the buffer, but previously it would clear the buffer when it received the first chunk of data.  That means that we could't consume data into an existing buffer while keeping any previous contents.  This patch updates the consumer implementation to actually perform an append.
