### PR TITLE
cork_strndup should copy entire string

### DIFF
--- a/src/libcork/core/allocator.c
+++ b/src/libcork/core/allocator.c
@@ -223,7 +223,7 @@ strndup_internal(const struct cork_alloc *alloc,
     size_t  *new_str = cork_alloc_malloc(alloc, allocated_size);
     *new_str = allocated_size;
     dest = (char *) (void *) (new_str + 1);
-    strncpy(dest, str, len);
+    memcpy(dest, str, len);
     dest[len] = '\0';
     return dest;
 }
@@ -253,7 +253,7 @@ xstrndup_internal(const struct cork_alloc *alloc,
         char  *dest;
         *new_str = allocated_size;
         dest = (char *) (void *) (new_str + 1);
-        strncpy(dest, str, len);
+        memcpy(dest, str, len);
         dest[len] = '\0';
         return dest;
     }

--- a/tests/test-core.c
+++ b/tests/test-core.c
@@ -107,6 +107,39 @@ END_TEST
 
 
 /*-----------------------------------------------------------------------
+ * Strings
+ */
+
+static void
+test_strndup(const char *string, size_t size)
+{
+    const char  *copy;
+
+    copy = cork_strndup(string, size);
+    if (memcmp(string, copy, size) != 0) {
+        fail("cork_strndup failed");
+    }
+    cork_strfree(copy);
+
+    copy = cork_xstrndup(string, size);
+    fail_if(copy == NULL, "cork_xstrndup couldn't allocate copy");
+    if (memcmp(string, copy, size) != 0) {
+        fail("cork_xstrndup failed");
+    }
+    cork_strfree(copy);
+}
+
+START_TEST(test_string)
+{
+    DESCRIBE_TEST;
+    test_strndup("", 0);
+    test_strndup("abc", 3);
+    test_strndup("abc\x00xyz", 7);
+}
+END_TEST
+
+
+/*-----------------------------------------------------------------------
  * Endianness
  */
 
@@ -1054,6 +1087,10 @@ test_suite()
     tcase_add_test(tc_types, test_int_types);
     tcase_add_test(tc_types, test_int_sizeof);
     suite_add_tcase(s, tc_types);
+
+    TCase  *tc_string = tcase_create("string");
+    tcase_add_test(tc_string, test_string);
+    suite_add_tcase(s, tc_string);
 
     TCase  *tc_endianness = tcase_create("endianness");
     tcase_add_test(tc_endianness, test_endianness);


### PR DESCRIPTION
The `cork_strndup` and `cork_xstrndup` functions were using `strncpy` under the covers to make the copy of the incoming string.  This truncates the copy at the first NUL byte.  We want to copy the whole thing, so we should use `memcpy` instead.
