### PR TITLE
Make version detection work for commits on master

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,8 @@ if(VERSION_RESULT)
             "Cannot determine version number: " ${VERSION_RESULT})
 endif(VERSION_RESULT)
 # This causes an annoying extra prompt in ccmake.
-# message("Current version: " ${VERSION})
 
-string(REGEX REPLACE "-dev.*" "-dev" BASE_VERSION "${VERSION}")
+string(REGEX REPLACE "-.*" "-dev" BASE_VERSION "${VERSION}")
 
 if(BASE_VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-dev)?$")
     set(VERSION_MAJOR "${CMAKE_MATCH_1}")


### PR DESCRIPTION
I'm moving away from git-flow and just using a single `master` branch
moving forward.  This patch fixes the version detection logic to work
with the `git describe` output that results from this change.