### PR TITLE
Fix the build on i386

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ env:
   - ARCH=amd64 ENABLE_SHARED_EXECUTABLES=NO
 os:
   - linux
-  - osx
+  # TODO(dcreager): Reenable this once the Travis Mac backlog isn't quite so
+  # horrific.
+  # - osx
 install: .travis/install
 script: .travis/test
 

--- a/.travis/test
+++ b/.travis/test
@@ -8,6 +8,7 @@ cd .build
 if [ "$TRAVIS_OS_NAME" = linux ]; then
     if [ "$ARCH" = i386 ]; then
         ARCH_FLAGS="-m32"
+        export PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig
     else
         ARCH_FLAGS=""
     fi


### PR DESCRIPTION
Our Travis Linux builds run on a 64-bit machine, even when we're compiling and testing in 32-bit mode.  That means pkg-config by default will look in the 64-bit arch-specific directory for libcheck, even though we were (correctly) installing the 32-bit version of the library.  Debian ships a helper script for running pkg-config in cross-compile mode (/usr/share/pkg-config-crosswrapper), but all that does is set 
`PKG_CONFIG_PATH` to the appropriate values.  We can do that directly in our Travis script.