### PR TITLE
Fix unaligned access on sparc64

### DIFF
--- a/include/libcork/core/hash.h
+++ b/include/libcork/core/hash.h
@@ -17,6 +17,8 @@
 #include <libcork/core/types.h>
 #include <libcork/core/u128.h>
 
+/* Needed for memcpy */
+#include <string.h>
 
 #ifndef CORK_HASH_ATTRIBUTES
 #define CORK_HASH_ATTRIBUTES  CORK_ATTR_UNUSED static inline
@@ -41,6 +43,24 @@ typedef struct {
 
 #define CORK_ROTL32(a,b) (((a) << ((b) & 0x1f)) | ((a) >> (32 - ((b) & 0x1f))))
 #define CORK_ROTL64(a,b) (((a) << ((b) & 0x3f)) | ((a) >> (64 - ((b) & 0x3f))))
+
+CORK_ATTR_UNUSED
+static inline
+uint32_t cork_getblock32(const uint32_t *p, int i)
+{
+    uint32_t u;
+    memcpy(&u, p + i, sizeof(u));
+    return u;
+}
+
+CORK_ATTR_UNUSED
+static inline
+uint64_t cork_getblock64(const uint64_t *p, int i)
+{
+    uint64_t u;
+    memcpy(&u, p + i, sizeof(u));
+    return u;
+}
 
 CORK_ATTR_UNUSED
 static inline
@@ -87,7 +107,7 @@ cork_stable_hash_buffer(cork_hash seed, const void *src, size_t len)
 
     /* body */
     for (curr = blocks; curr != end; curr++) {
-        uint32_t  k1 = CORK_UINT32_HOST_TO_LITTLE(*curr);
+        uint32_t  k1 = CORK_UINT32_HOST_TO_LITTLE(cork_getblock32((const uint32_t *) curr, 0));
 
         k1 *= c1;
         k1 = CORK_ROTL32(k1,15);
@@ -129,7 +149,7 @@ do { \
     \
     /* body */ \
     for (curr = blocks; curr != end; curr++) { \
-        uint32_t  k1 = *curr; \
+        uint32_t  k1 = cork_getblock32((const uint32_t *) curr, 0); \
         \
         k1 *= c1; \
         k1 = CORK_ROTL32(k1,15); \
@@ -181,10 +201,10 @@ do { \
     \
     /* body */ \
     for (curr = blocks; curr != end; curr += 4) { \
-        uint32_t  k1 = curr[0]; \
-        uint32_t  k2 = curr[1]; \
-        uint32_t  k3 = curr[2]; \
-        uint32_t  k4 = curr[3]; \
+        uint32_t  k1 = cork_getblock32((const uint32_t *) curr, 0); \
+        uint32_t  k2 = cork_getblock32((const uint32_t *) curr, 1); \
+        uint32_t  k3 = cork_getblock32((const uint32_t *) curr, 2); \
+        uint32_t  k4 = cork_getblock32((const uint32_t *) curr, 3); \
         \
         k1 *= c1; k1  = CORK_ROTL32(k1,15); k1 *= c2; h1 ^= k1; \
         h1 = CORK_ROTL32(h1,19); h1 += h2; h1 = h1*5+0x561ccd1b; \
@@ -264,8 +284,8 @@ do { \
     \
     /* body */ \
     for (curr = blocks; curr != end; curr += 2) { \
-        uint64_t  k1 = curr[0]; \
-        uint64_t  k2 = curr[1]; \
+        uint64_t  k1 = cork_getblock64((const uint64_t *) curr, 0); \
+        uint64_t  k2 = cork_getblock64((const uint64_t *) curr, 1); \
     \
         k1 *= c1; k1  = CORK_ROTL64(k1,31); k1 *= c2; h1 ^= k1; \
         h1 = CORK_ROTL64(h1,27); h1 += h2; h1 = h1*5+0x52dce729; \


### PR DESCRIPTION
[ rebased pull-request of #119 ]
It's intended to fix #118.
This issue was discussed in debian-sparc lists, and patch is from:

https://lists.debian.org/debian-sparc/2016/08/msg00035.html
I didn't test this yet, just want to ask upstream's opinion on this fix.
Thank you!