### PR TITLE
Don't print anything to stderr in cork-test

### DIFF
--- a/tests/cork-test/run-paths-01.t
+++ b/tests/cork-test/run-paths-01.t
@@ -11,11 +11,11 @@
   > XDG_CACHE_HOME= \
   > XDG_RUNTIME_DIR= \
   >     cork-test paths
-  Cannot determine user-specific runtime directory
   Home:    /home/test
   Config:  /home/test/.config:/etc/xdg
   Data:    /home/test/.local/share:/usr/local/share:/usr/share
   Cache:   /home/test/.cache
+  Cannot determine user-specific runtime directory
   [1]
 
   $ HOME=/home/test \


### PR DESCRIPTION
This is only used in cram test cases, where it's not defined how stdout and stderr are interleaved together.  By only printing the stdout, we should end up with a deterministic ordering for all of the lines in the expected test output.

Fixes: #124