### PR TITLE
Update multi-arch support to fix build error on ubuntu yakkety

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,8 @@ if(GIT_SHA1_RESULT)
             "Cannot determine git commit: " ${GIT_SHA1_RESULT})
 endif(GIT_SHA1_RESULT)
 
+include(GNUInstallDirs)
+
 #-----------------------------------------------------------------------
 # Check for building on Tilera
 # If the Tilera environment is installed, then $TILERA_ROOT is defined
@@ -97,8 +99,10 @@ set(ENABLE_SHARED_EXECUTABLES NO CACHE BOOL
     "Whether to link executables using shared libraries")
 set(ENABLE_STATIC YES CACHE BOOL "Whether to build a static library")
 
-set(CMAKE_INSTALL_LIBDIR lib CACHE STRING
-    "The base name of the installation directory for libraries")
+if(NOT CMAKE_INSTALL_LIBDIR)
+    set(CMAKE_INSTALL_LIBDIR lib CACHE STRING
+        "The base name of the installation directory for libraries")
+endif(NOT CMAKE_INSTALL_LIBDIR)
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     add_definitions(-Wall -Werror)
@@ -107,8 +111,6 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "Clang")
 elseif(CMAKE_C_COMPILER_ID STREQUAL "Intel")
     add_definitions(-Wall -Werror)
 endif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-
-include(GNUInstallDirs)
 
 #-----------------------------------------------------------------------
 # Check for prerequisite libraries


### PR DESCRIPTION
After previous multi-arch support patch, build is okay for debian,
but not for ubuntu yakkety:
  https://launchpadlibrarian.net/271663979/buildlog_ubuntu-yakkety-amd64.libcork_0.15.0+ds-4_BUILDING.txt.gz

====
make[2]: Leaving directory '/«BUILDDIR»/libcork-0.15.0+ds/build'
make[1]: Leaving directory '/«BUILDDIR»/libcork-0.15.0+ds'
   dh_install -O--builddirectory=build
dh_install: Cannot find (any matches for) "usr/lib/*/lib*.so" (tried in "." and "debian/tmp")
dh_install: libcork-dev missing files: usr/lib/*/lib*.so
dh_install: Cannot find (any matches for) "usr/lib/*/pkgconfig/*" (tried in "." and "debian/tmp")
dh_install: libcork-dev missing files: usr/lib/*/pkgconfig/*
dh_install: Cannot find (any matches for) "usr/lib/*/lib*.so.*" (tried in "." and "debian/tmp")
dh_install: libcork15 missing files: usr/lib/*/lib*.so.*
dh_install: missing files, aborting
make: *** [binary] Error 2
dpkg-buildpackage: error: fakeroot debian/rules binary gave error exit status 2
debian/rules:14: recipe for target 'binary' failed
====

After applying this patch, build are OK for both debian and ubuntu.