### PR TITLE
Fix processing of libtool-style version-info

### DIFF
--- a/cmake/FindCTargets.cmake
+++ b/cmake/FindCTargets.cmake
@@ -51,19 +51,23 @@ set_property(GLOBAL PROPERTY ALL_LOCAL_LIBRARIES "")
 
 function(add_c_library __TARGET_NAME)
     set(options)
-    set(one_args OUTPUT_NAME PKGCONFIG_NAME VERSION)
+    set(one_args OUTPUT_NAME PKGCONFIG_NAME VERSION_INFO)
     set(multi_args LIBRARIES LOCAL_LIBRARIES SOURCES)
     cmake_parse_arguments(_ "${options}" "${one_args}" "${multi_args}" ${ARGN})
 
-    if (__VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-dev)?$")
+    if (__VERSION_INFO MATCHES "^([0-9]+):([0-9]+):([0-9]+)(-dev)?$")
         set(__VERSION_CURRENT  "${CMAKE_MATCH_1}")
         set(__VERSION_REVISION "${CMAKE_MATCH_2}")
         set(__VERSION_AGE      "${CMAKE_MATCH_3}")
-    else (__VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-dev)?$")
-        message(FATAL_ERROR "Invalid library version number: ${__VERSION}")
-    endif (__VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-dev)?$")
+    else (__VERSION_INFO MATCHES "^([0-9]+):([0-9]+):([0-9]+)(-dev)?$")
+        message(FATAL_ERROR "Invalid library version info: ${__VERSION_INFO}")
+    endif (__VERSION_INFO MATCHES "^([0-9]+):([0-9]+):([0-9]+)(-dev)?$")
 
+    # Mimic libtool's behavior in calculating SONAME and VERSION from
+    # version-info.
+    # http://git.savannah.gnu.org/cgit/libtool.git/tree/build-aux/ltmain.in?id=722b6af0fad19b3d9f21924ae5aa6dfae5957378#n7042
     math(EXPR __SOVERSION "${__VERSION_CURRENT} - ${__VERSION_AGE}")
+    set(__VERSION "${__SOVERSION}.${__VERSION_AGE}.${__VERSION_REVISION}")
 
     get_property(ALL_LOCAL_LIBRARIES GLOBAL PROPERTY ALL_LOCAL_LIBRARIES)
     list(APPEND ALL_LOCAL_LIBRARIES ${__TARGET_NAME})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,17 +9,17 @@
 #-----------------------------------------------------------------------
 # libcork
 
-# Update the VERSION property below according to the following rules (taken from
-# [1]):
+# Update the VERSION_INFO property below according to the following rules (taken
+# from [1]):
 #
-# VERSION = current.revision.age
+# VERSION_INFO = current:revision:age
 #
-#   1. Start with a VERSION of `0.0.0` for each shared library.
-#   2. Update VERSION only immediately before a public release of your software.
-#      More frequent updates are unnecessary, and only guarantee that the
-#      current interface number gets larger faster.
+#   1. Start with a VERSION of `0:0:0` for each shared library.
+#   2. Update VERSION_INFO only immediately before a public release of your
+#      software.  More frequent updates are unnecessary, and only guarantee that
+#      the current interface number gets larger faster.
 #   3. If the library source code has changed at all since the last update, then
-#      increment `revision` (`c.r.a` becomes `c.r+1.a`).
+#      increment `revision` (`c:r:a` becomes `c:r+1:a`).
 #   4. If any interfaces have been added, removed, or changed since the last
 #      update, increment `current`, and set `revision` to 0.
 #   5. If any interfaces have been added since the last public release, then
@@ -27,9 +27,10 @@
 #   6. If any interfaces have been removed or changed since the last public
 #      release, then set `age` to 0.
 #
-# Note that changing `current` means that you are releasing a new
-# backwards-incompatible version of the library.  This has implications on
-# packaging, so once an API has stabilized, this should be a rare occurrence.
+# Note that changing `current` and setting `age` to 0 means that you are
+# releasing a new backwards-incompatible version of the library.  This has
+# implications on packaging, so once an API has stabilized, this should be a
+# rare occurrence.
 #
 # [1] http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html#Updating-version-info
 
@@ -37,7 +38,7 @@ add_c_library(
     libcork
     OUTPUT_NAME cork
     PKGCONFIG_NAME libcork
-    VERSION 16.0.1
+    VERSION_INFO 16:3:0
     SOURCES
         libcork/cli/commands.c
         libcork/core/allocator.c


### PR DESCRIPTION
We were calculating the SONAME correctly, but not the version encoded into the .so filename.  This patch updates our CMake rules to line up with what libtool does, and changes the name and format of the paramater to make it clearer that this should line up with libtool's -version-info parameter.