### PR TITLE
Add CORK_FINALIZER macro

### DIFF
--- a/docs/old/attributes.rst
+++ b/docs/old/attributes.rst
@@ -101,10 +101,12 @@ common compiler attributes.
 
 
 .. macro:: CORK_INITIALIZER(func_name)
+           CORK_FINALIZER(func_name)
 
    Declare a ``static`` function that will be automatically called at program
-   startup.  If there are multiple initializer functions linked into a program,
-   there is no guarantee about the order in which the functions will be called.
+   startup (for ``CORK_INITIALIZER``) or shutdown (for ``CORK_FINALIZER``).  If
+   there are multiple initializer functions linked into a program, there is no
+   guarantee about the order in which the functions will be called.
 
    ::
 
@@ -116,4 +118,9 @@ common compiler attributes.
      CORK_INITIALIZER(init_array)
      {
         cork_array_init(&array);
+     }
+
+     CORK_FINALIZER(done_array)
+     {
+        cork_array_done(&array);
      }

--- a/include/libcork/core/attributes.h
+++ b/include/libcork/core/attributes.h
@@ -159,10 +159,17 @@
  */
 
 #if CORK_CONFIG_HAVE_GCC_ATTRIBUTES
+
 #define CORK_INITIALIZER(name) \
 __attribute__((constructor)) \
 static void \
 name(void)
+
+#define CORK_FINALIZER(name) \
+__attribute__((destructor)) \
+static void \
+name(void)
+
 #else
 #error "Don't know how to implement initialization functions of this platform"
 #endif

--- a/src/cork-initializer/init1.c
+++ b/src/cork-initializer/init1.c
@@ -15,3 +15,8 @@ CORK_INITIALIZER(init)
 {
     printf("Initializer 1\n");
 }
+
+CORK_FINALIZER(done)
+{
+    printf("Finalizer 1\n");
+}

--- a/tests/cork-initializer.t
+++ b/tests/cork-initializer.t
@@ -2,5 +2,6 @@ We need to sort the output, since there's no guarantee about which order our
 initializer functions will run in.
 
   $ cork-initializer | sort
+  Finalizer 1
   Initializer 1
   Initializer 2


### PR DESCRIPTION
We already have `CORK_INITIALIZER`, which is basically just GCC's `__attribute__((constructor))`, with a comment to eventually add something equivalent for Windows.  This patch adds the corresponding `CORK_FINALIZER`, for destructor functions.