### PR TITLE
Use Travis container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,14 @@
+dist: trusty
+sudo: false
+addons:
+  apt:
+    packages:
+      - check
+      # This one is only needed for ARCH=i386, but we can't add conditional
+      # package dependencies in this section
+      - check:i386
+      - gcc-multilib
+
 language: c
 compiler:
   - clang

--- a/.travis/install
+++ b/.travis/install
@@ -2,14 +2,6 @@
 
 set -e
 
-if [ "$TRAVIS_OS_NAME" = linux ]; then
-    sudo apt-get update -qq
-
-    if [ "$ARCH" = i386 ]; then
-        sudo apt-get install gcc-multilib
-    fi
-
-    sudo apt-get install check:$ARCH
-else
+if [ "$TRAVIS_OS_NAME" = osx ]; then
     brew install --universal check
 fi


### PR DESCRIPTION
This should speed up our builds.  The only wrinkle is that we have a package that we only technically need when performing a 32-bit build.  There's no way (that I know of) to conditionally install that package in the container world like we were doing before.  But it doesn't hurt anything to install the package when it's not needed.