### PR TITLE
Change library link order to fix missing libcheck symbols

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,7 @@ macro(make_test test_name)
     target_link_libraries(${test_name} ${CHECK_LIBRARIES} libcork-shared)
   else (ENABLE_SHARED_TESTS)
     set_target_properties(${test_name} PROPERTIES COMPILE_DEFINITIONS CORK_EMBEDDED_TEST=1)
-    target_link_libraries(${test_name} ${CHECK_LIBRARIES} libcork-static)
+    target_link_libraries(${test_name} libcork-static ${CHECK_LIBRARIES})
   endif (ENABLE_SHARED_TESTS)
 endmacro(make_test)
 


### PR DESCRIPTION
I had to change the link order for libcheck as I ran into missing symbols like 'tcase_fn_start' and '_mark_point'.