### PR TITLE
Add CORK_INLINE attribute

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -122,6 +122,7 @@ libcork_la_SOURCES = \
     src/libcork/core/error.c \
     src/libcork/core/gc.c \
     src/libcork/core/hash.c \
+    src/libcork/core/id.c \
     src/libcork/core/ip-address.c \
     src/libcork/core/mempool.c \
     src/libcork/core/timestamp.c \
@@ -136,6 +137,7 @@ libcork_la_SOURCES = \
     src/libcork/ds/managed-buffer.c \
     src/libcork/ds/ring-buffer.c \
     src/libcork/ds/slice.c \
+    src/libcork/ds/stream.c \
     src/libcork/posix/directory-walker.c \
     src/libcork/posix/env.c \
     src/libcork/posix/exec.c \

--- a/configure.ac
+++ b/configure.ac
@@ -30,11 +30,8 @@ AC_SUBST(VERSION_MINOR, [`AS_ECHO([$BASE_VERSION]) | $AWK -F. '{print $2}'`])
 AC_SUBST(VERSION_PATCH, [`AS_ECHO([$BASE_VERSION]) | $AWK -F. '{print $3}'`])
 AC_SUBST(GIT_SHA1, m4_esyscmd([build-aux/calculate commit .commit-stamp]))
 AC_CONFIG_FILES([include/libcork/config/version.h])
-
-# Turn on fatal warnings by default; you can override this by setting CPPFLAGS
-# to something else when running configure.
-: ${CPPFLAGS="-Wall -Werror"}
 AC_PROG_CC
+AC_PROG_CC_C99
 
 # TAP support
 AC_PROG_AWK
@@ -59,6 +56,10 @@ AX_VALGRIND_DFLT([helgrind], [off])
 AX_VALGRIND_DFLT([drd], [off])
 AX_VALGRIND_DFLT([sgcheck], [off])
 AX_VALGRIND_CHECK()
+
+# Turn on fatal warnings by default; you can override this by setting CPPFLAGS
+# to something else when running configure.
+: ${CPPFLAGS="-Wall -Werror"}
 
 AC_OUTPUT([Makefile])
 

--- a/include/libcork/config/gcc.h
+++ b/include/libcork/config/gcc.h
@@ -56,6 +56,13 @@
 #endif
 #endif
 
+/* C99 inline is available if we're compiling in C99 mode. */
+#if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#define CORK_CONFIG_HAVE_C99_INLINE  1
+#else
+#define CORK_CONFIG_HAVE_C99_INLINE  0
+#endif
+
 /* __int128 seems to be available on 64-bit platforms as of GCC 4.6.  The
  * attribute((mode(TI))) syntax seems to be available as of 4.1. */
 

--- a/include/libcork/core/allocator.h
+++ b/include/libcork/core/allocator.h
@@ -101,24 +101,24 @@ cork_alloc_set_free(struct cork_alloc *alloc, cork_alloc_free_f free);
 /* Low-level use of an allocator. */
 
 CORK_ATTR_MALLOC
-CORK_ATTR_UNUSED
-static void *
+CORK_INLINE
+void *
 cork_alloc_calloc(const struct cork_alloc *alloc, size_t count, size_t size)
 {
     return alloc->calloc(alloc, count, size);
 }
 
 CORK_ATTR_MALLOC
-CORK_ATTR_UNUSED
-static void *
+CORK_INLINE
+void *
 cork_alloc_malloc(const struct cork_alloc *alloc, size_t size)
 {
     return alloc->malloc(alloc, size);
 }
 
 CORK_ATTR_MALLOC
-CORK_ATTR_UNUSED
-static void *
+CORK_INLINE
+void *
 cork_alloc_realloc(const struct cork_alloc *alloc, void *ptr,
                    size_t old_size, size_t new_size)
 {
@@ -126,24 +126,24 @@ cork_alloc_realloc(const struct cork_alloc *alloc, void *ptr,
 }
 
 CORK_ATTR_MALLOC
-CORK_ATTR_UNUSED
-static void *
+CORK_INLINE
+void *
 cork_alloc_xcalloc(const struct cork_alloc *alloc, size_t count, size_t size)
 {
     return alloc->xcalloc(alloc, count, size);
 }
 
 CORK_ATTR_MALLOC
-CORK_ATTR_UNUSED
-static void *
+CORK_INLINE
+void *
 cork_alloc_xmalloc(const struct cork_alloc *alloc, size_t size)
 {
     return alloc->xmalloc(alloc, size);
 }
 
 CORK_ATTR_MALLOC
-CORK_ATTR_UNUSED
-static void *
+CORK_INLINE
+void *
 cork_alloc_xrealloc(const struct cork_alloc *alloc, void *ptr,
                     size_t old_size, size_t new_size)
 {
@@ -151,8 +151,8 @@ cork_alloc_xrealloc(const struct cork_alloc *alloc, void *ptr,
 }
 
 CORK_ATTR_MALLOC
-CORK_ATTR_UNUSED
-static void *
+CORK_INLINE
+void *
 cork_alloc_xreallocf(const struct cork_alloc *alloc, void *ptr,
                      size_t old_size, size_t new_size)
 {
@@ -165,15 +165,15 @@ cork_alloc_xreallocf(const struct cork_alloc *alloc, void *ptr,
     }
 }
 
-CORK_ATTR_UNUSED
-static void
+CORK_INLINE
+void
 cork_alloc_free(const struct cork_alloc *alloc, void *ptr, size_t size)
 {
     return alloc->free(alloc, ptr, size);
 }
 
-CORK_ATTR_UNUSED
-static void
+CORK_INLINE
+void
 cork_alloc_cfree(const struct cork_alloc *alloc, void *ptr,
                  size_t count, size_t size)
 {
@@ -260,8 +260,8 @@ cork_set_allocator(const struct cork_alloc *alloc);
 /* using an allocator */
 
 CORK_ATTR_MALLOC
-CORK_ATTR_UNUSED
-static void *
+CORK_INLINE
+void *
 cork_calloc(size_t count, size_t size)
 {
     const struct cork_alloc  *alloc = cork_current_allocator();
@@ -269,8 +269,8 @@ cork_calloc(size_t count, size_t size)
 }
 
 CORK_ATTR_MALLOC
-CORK_ATTR_UNUSED
-static void *
+CORK_INLINE
+void *
 cork_malloc(size_t size)
 {
     const struct cork_alloc  *alloc = cork_current_allocator();
@@ -278,8 +278,8 @@ cork_malloc(size_t size)
 }
 
 CORK_ATTR_MALLOC
-CORK_ATTR_UNUSED
-static void *
+CORK_INLINE
+void *
 cork_realloc(void *ptr, size_t old_size, size_t new_size)
 {
     const struct cork_alloc  *alloc = cork_current_allocator();
@@ -287,8 +287,8 @@ cork_realloc(void *ptr, size_t old_size, size_t new_size)
 }
 
 CORK_ATTR_MALLOC
-CORK_ATTR_UNUSED
-static void *
+CORK_INLINE
+void *
 cork_xcalloc(size_t count, size_t size)
 {
     const struct cork_alloc  *alloc = cork_current_allocator();
@@ -296,8 +296,8 @@ cork_xcalloc(size_t count, size_t size)
 }
 
 CORK_ATTR_MALLOC
-CORK_ATTR_UNUSED
-static void *
+CORK_INLINE
+void *
 cork_xmalloc(size_t size)
 {
     const struct cork_alloc  *alloc = cork_current_allocator();
@@ -305,8 +305,8 @@ cork_xmalloc(size_t size)
 }
 
 CORK_ATTR_MALLOC
-CORK_ATTR_UNUSED
-static void *
+CORK_INLINE
+void *
 cork_xrealloc(void *ptr, size_t old_size, size_t new_size)
 {
     const struct cork_alloc  *alloc = cork_current_allocator();
@@ -314,24 +314,24 @@ cork_xrealloc(void *ptr, size_t old_size, size_t new_size)
 }
 
 CORK_ATTR_MALLOC
-CORK_ATTR_UNUSED
-static void *
+CORK_INLINE
+void *
 cork_xreallocf(void *ptr, size_t old_size, size_t new_size)
 {
     const struct cork_alloc  *alloc = cork_current_allocator();
     return cork_alloc_xreallocf(alloc, ptr, old_size, new_size);
 }
 
-CORK_ATTR_UNUSED
-static void
+CORK_INLINE
+void
 cork_free(void *ptr, size_t size)
 {
     const struct cork_alloc  *alloc = cork_current_allocator();
     cork_alloc_free(alloc, ptr, size);
 }
 
-CORK_ATTR_UNUSED
-static void
+CORK_INLINE
+void
 cork_cfree(void *ptr, size_t count, size_t size)
 {
     const struct cork_alloc  *alloc = cork_current_allocator();
@@ -346,8 +346,8 @@ cork_cfree(void *ptr, size_t count, size_t size)
 /* string-related helper functions */
 
 CORK_ATTR_MALLOC
-CORK_ATTR_UNUSED
-static const char *
+CORK_INLINE
+const char *
 cork_strdup(const char *str)
 {
     const struct cork_alloc  *alloc = cork_current_allocator();
@@ -355,8 +355,8 @@ cork_strdup(const char *str)
 }
 
 CORK_ATTR_MALLOC
-CORK_ATTR_UNUSED
-static const char *
+CORK_INLINE
+const char *
 cork_strndup(const char *str, size_t size)
 {
     const struct cork_alloc  *alloc = cork_current_allocator();
@@ -364,8 +364,8 @@ cork_strndup(const char *str, size_t size)
 }
 
 CORK_ATTR_MALLOC
-CORK_ATTR_UNUSED
-static const char *
+CORK_INLINE
+const char *
 cork_xstrdup(const char *str)
 {
     const struct cork_alloc  *alloc = cork_current_allocator();
@@ -373,16 +373,16 @@ cork_xstrdup(const char *str)
 }
 
 CORK_ATTR_MALLOC
-CORK_ATTR_UNUSED
-static const char *
+CORK_INLINE
+const char *
 cork_xstrndup(const char *str, size_t size)
 {
     const struct cork_alloc  *alloc = cork_current_allocator();
     return cork_alloc_xstrndup(alloc, str, size);
 }
 
-CORK_ATTR_UNUSED
-static void
+CORK_INLINE
+void
 cork_strfree(const char *str)
 {
     const struct cork_alloc  *alloc = cork_current_allocator();

--- a/include/libcork/core/attributes.h
+++ b/include/libcork/core/attributes.h
@@ -146,6 +146,20 @@
 #define CORK_LOCAL
 #endif
 
+/*
+ * Define an inline function in a header file.  This allows the compiler to
+ * inline the definition if it makes sense.  You should also provide a
+ * _declaration_ in some source file, with exactly the same signature, which
+ * will ensure that a single copy of the function is available to link against
+ * if the compiler decides not to inline the function.
+ */
+
+#if CORK_CONFIG_HAVE_C99_INLINE
+#define CORK_INLINE inline
+#else
+#define CORK_INLINE CORK_ATTR_UNUSED static
+#endif
+
 
 /*
  * Declare a static function that should automatically be called at program

--- a/include/libcork/core/error.h
+++ b/include/libcork/core/error.h
@@ -117,8 +117,8 @@ cork_unknown_error_set_(const char *location);
 #define cork_abort(fmt, ...) \
     cork_abort_(__func__, __FILE__, __LINE__, fmt, __VA_ARGS__)
 
-CORK_ATTR_UNUSED
-static void *
+CORK_INLINE
+void *
 cork_abort_if_null_(void *ptr, const char *msg, const char *func,
                     const char *file, unsigned int line)
 {

--- a/include/libcork/core/hash.h
+++ b/include/libcork/core/hash.h
@@ -20,10 +20,6 @@
 /* Needed for memcpy */
 #include <string.h>
 
-#ifndef CORK_HASH_ATTRIBUTES
-#define CORK_HASH_ATTRIBUTES  CORK_ATTR_UNUSED static inline
-#endif
-
 
 typedef uint32_t  cork_hash;
 
@@ -31,7 +27,12 @@ typedef struct {
     cork_u128  u128;
 } cork_big_hash;
 
-#define cork_big_hash_equal(h1, h2)  (cork_u128_eq((h1).u128, (h2).u128))
+CORK_INLINE
+bool
+cork_big_hash_equal(const cork_big_hash h1, const cork_big_hash h2)
+{
+    return cork_u128_eq(h1.u128, h2.u128);
+}
 
 #define CORK_BIG_HASH_INIT()  {{{{0}}}}
 
@@ -44,8 +45,7 @@ typedef struct {
 #define CORK_ROTL32(a,b) (((a) << ((b) & 0x1f)) | ((a) >> (32 - ((b) & 0x1f))))
 #define CORK_ROTL64(a,b) (((a) << ((b) & 0x3f)) | ((a) >> (64 - ((b) & 0x3f))))
 
-CORK_ATTR_UNUSED
-static inline
+CORK_INLINE
 uint32_t cork_getblock32(const uint32_t *p, int i)
 {
     uint32_t u;
@@ -53,8 +53,7 @@ uint32_t cork_getblock32(const uint32_t *p, int i)
     return u;
 }
 
-CORK_ATTR_UNUSED
-static inline
+CORK_INLINE
 uint64_t cork_getblock64(const uint64_t *p, int i)
 {
     uint64_t u;
@@ -62,8 +61,7 @@ uint64_t cork_getblock64(const uint64_t *p, int i)
     return u;
 }
 
-CORK_ATTR_UNUSED
-static inline
+CORK_INLINE
 uint32_t cork_fmix32(uint32_t h)
 {
     h ^= h >> 16;
@@ -74,8 +72,7 @@ uint32_t cork_fmix32(uint32_t h)
     return h;
 }
 
-CORK_ATTR_UNUSED
-static inline
+CORK_INLINE
 uint64_t cork_fmix64(uint64_t k)
 {
     k ^= k >> 33;
@@ -86,7 +83,7 @@ uint64_t cork_fmix64(uint64_t k)
     return k;
 }
 
-CORK_HASH_ATTRIBUTES
+CORK_INLINE
 cork_hash
 cork_stable_hash_buffer(cork_hash seed, const void *src, size_t len)
 {
@@ -333,8 +330,7 @@ do { \
 } while (0)
 
 
-#include <stdio.h>
-CORK_HASH_ATTRIBUTES
+CORK_INLINE
 cork_hash
 cork_hash_buffer(cork_hash seed, const void *src, size_t len)
 {
@@ -351,7 +347,7 @@ cork_hash_buffer(cork_hash seed, const void *src, size_t len)
 }
 
 
-CORK_HASH_ATTRIBUTES
+CORK_INLINE
 cork_big_hash
 cork_big_hash_buffer(cork_big_hash seed, const void *src, size_t len)
 {

--- a/include/libcork/core/id.h
+++ b/include/libcork/core/id.h
@@ -10,6 +10,7 @@
 #ifndef LIBCORK_CORE_ID_H
 #define LIBCORK_CORE_ID_H
 
+#include <libcork/core/attributes.h>
 #include <libcork/core/hash.h>
 
 
@@ -27,9 +28,26 @@ typedef const struct cork_uid  *cork_uid;
 #define cork_uid_define(c_name) \
     cork_uid_define_named(c_name, #c_name)
 
-#define cork_uid_equal(id1, id2)  ((id1) == (id2))
-#define cork_uid_hash(id)         ((cork_hash) (uintptr_t) (id))
-#define cork_uid_name(id)         ((id)->name)
+CORK_INLINE
+bool
+cork_uid_equal(const cork_uid id1, const cork_uid id2)
+{
+    return id1 == id2;
+}
+
+CORK_INLINE
+cork_hash
+cork_uid_hash(const cork_uid id)
+{
+    return (cork_hash) (uintptr_t) id;
+}
+
+CORK_INLINE
+const char*
+cork_uid_name(const cork_uid id)
+{
+    return id->name;
+}
 
 
 #endif /* LIBCORK_CORE_ID_H */

--- a/include/libcork/core/mempool.h
+++ b/include/libcork/core/mempool.h
@@ -27,9 +27,13 @@ struct cork_mempool;
 CORK_API struct cork_mempool *
 cork_mempool_new_size_ex(size_t element_size, size_t block_size);
 
-#define cork_mempool_new_size(element_size) \
-    (cork_mempool_new_size_ex \
-     ((element_size), CORK_MEMPOOL_DEFAULT_BLOCK_SIZE))
+CORK_INLINE
+struct cork_mempool*
+cork_mempool_new_size(size_t element_size)
+{
+    return cork_mempool_new_size_ex(
+            element_size, CORK_MEMPOOL_DEFAULT_BLOCK_SIZE);
+}
 
 #define cork_mempool_new_ex(type, block_size) \
     (cork_mempool_new_size_ex(sizeof(type), (block_size)))

--- a/include/libcork/core/net-addresses.h
+++ b/include/libcork/core/net-addresses.h
@@ -14,6 +14,7 @@
 #include <string.h>
 
 #include <libcork/core/api.h>
+#include <libcork/core/attributes.h>
 #include <libcork/core/error.h>
 #include <libcork/core/types.h>
 
@@ -58,11 +59,19 @@ struct cork_ip {
 /*** IPv4 ***/
 
 /* src must be well-formed: 4 bytes, big-endian */
-#define cork_ipv4_copy(addr, src) \
-    (memcpy((addr), (src), sizeof(struct cork_ipv4)))
+CORK_INLINE
+void
+cork_ipv4_copy(struct cork_ipv4* addr, const void* src)
+{
+    memcpy(addr, src, sizeof(struct cork_ipv4));
+}
 
-#define cork_ipv4_equal(a1, a2) \
-    ((a1)->_.u32 == (a2)->_.u32)
+CORK_INLINE
+bool
+cork_ipv4_equal(const struct cork_ipv4* addr1, const struct cork_ipv4* addr2)
+{
+    return addr1->_.u32 == addr2->_.u32;
+}
 
 CORK_API int
 cork_ipv4_init(struct cork_ipv4 *addr, const char *str);
@@ -81,12 +90,20 @@ cork_ipv4_is_valid_network(const struct cork_ipv4 *addr,
 /*** IPv6 ***/
 
 /* src must be well-formed: 16 bytes, big-endian */
-#define cork_ipv6_copy(addr, src) \
-    (memcpy((addr), (src), sizeof(struct cork_ipv6)))
+CORK_INLINE
+void
+cork_ipv6_copy(struct cork_ipv6* addr, const void* src)
+{
+    memcpy(addr, src, sizeof(struct cork_ipv6));
+}
 
-#define cork_ipv6_equal(a1, a2) \
-    ((a1)->_.u64[0] == (a2)->_.u64[0] && \
-     (a1)->_.u64[1] == (a2)->_.u64[1])
+CORK_INLINE
+bool
+cork_ipv6_equal(const struct cork_ipv6* addr1, const struct cork_ipv6* addr2)
+{
+    return addr1->_.u64[0] == addr2->_.u64[0] &&
+        addr1->_.u64[1] == addr2->_.u64[1];
+}
 
 CORK_API int
 cork_ipv6_init(struct cork_ipv6 *addr, const char *str);
@@ -104,38 +121,39 @@ cork_ipv6_is_valid_network(const struct cork_ipv6 *addr,
 
 /*** Generic IP ***/
 
-#define cork_ip_equal(a1, a2) \
-    ((a1)->version == 4? \
-     ((a2)->version == 4 && cork_ipv4_equal(&(a1)->ip.v4, &(a2)->ip.v4)): \
-     ((a2)->version == 6 && cork_ipv6_equal(&(a1)->ip.v6, &(a2)->ip.v6)))
+CORK_INLINE
+bool
+cork_ip_equal(const struct cork_ip* addr1, const struct cork_ip* addr2)
+{
+    if (addr1->version != addr2->version)
+        return false;
+    else if (addr1->version == 4) {
+        return cork_ipv4_equal(&addr1->ip.v4, &addr2->ip.v4);
+    } else {
+        return cork_ipv6_equal(&addr1->ip.v6, &addr2->ip.v6);
+    }
+}
 
 /* src must be well-formed: 4 bytes, big-endian */
-#define cork_ip_from_ipv4(addr, src) \
-    do { \
-        (addr)->version = 4; \
-        cork_ipv4_copy(&(addr)->ip.v4, (src)); \
-    } while (0)
+CORK_INLINE
+void
+cork_ip_from_ipv4(struct cork_ip* addr, const void* src)
+{
+    addr->version = 4;
+    cork_ipv4_copy(&addr->ip.v4, src);
+}
 
 /* src must be well-formed: 16 bytes, big-endian */
-#define cork_ip_from_ipv6(addr, src) \
-    do { \
-        (addr)->version = 6; \
-        cork_ipv6_copy(&(addr)->ip.v6, (src)); \
-    } while (0)
-
-/* src must be well-formed: 4 bytes, big-endian */
-CORK_API void
-cork_ip_from_ipv4_(struct cork_ip *addr, const void *src);
-
-/* src must be well-formed: 16 bytes, big-endian */
-CORK_API void
-cork_ip_from_ipv6_(struct cork_ip *addr, const void *src);
+CORK_INLINE
+void
+cork_ip_from_ipv6(struct cork_ip* addr, const void* src)
+{
+    addr->version = 6;
+    cork_ipv6_copy(&addr->ip.v6, src);
+}
 
 CORK_API int
 cork_ip_init(struct cork_ip *addr, const char *str);
-
-CORK_API bool
-cork_ip_equal_(const struct cork_ip *addr1, const struct cork_ip *addr2);
 
 CORK_API void
 cork_ip_to_raw_string(const struct cork_ip *addr, char *dest);

--- a/include/libcork/core/timestamp.h
+++ b/include/libcork/core/timestamp.h
@@ -20,45 +20,62 @@
 typedef uint64_t  cork_timestamp;
 
 
-#define cork_timestamp_init_sec(ts, sec) \
-    do { \
-        *(ts) = (((uint64_t) (sec)) << 32); \
-    } while (0)
+CORK_INLINE
+void
+cork_timestamp_init_sec(cork_timestamp* ts, uint64_t sec)
+{
+    *ts = sec << 32;
+}
 
-#define cork_timestamp_init_gsec(ts, sec, gsec) \
-    do { \
-        *(ts) = (((uint64_t) (sec)) << 32) | \
-                (((uint64_t) (gsec)) & 0xffffffff); \
-    } while (0)
+CORK_INLINE
+void
+cork_timestamp_init_gsec(cork_timestamp* ts, uint64_t sec, uint64_t gsec)
+{
+    *ts = (sec << 32) | (gsec & 0xffffffff);
+}
 
-#define cork_timestamp_init_msec(ts, sec, msec) \
-    do { \
-        *(ts) = (((uint64_t) (sec)) << 32) | \
-                ((((uint64_t) (msec)) << 32) / 1000); \
-    } while (0)
+CORK_INLINE
+void
+cork_timestamp_init_msec(cork_timestamp* ts, uint64_t sec, uint64_t msec)
+{
+    *ts = (sec << 32) | ((msec << 32) / 1000);
+}
 
-#define cork_timestamp_init_usec(ts, sec, usec) \
-    do { \
-        *(ts) = (((uint64_t) (sec)) << 32) | \
-                ((((uint64_t) (usec)) << 32) / 1000000); \
-    } while (0)
+CORK_INLINE
+void
+cork_timestamp_init_usec(cork_timestamp* ts, uint64_t sec, uint64_t usec)
+{
+    *ts = (sec << 32) | ((usec << 32) / 1000000);
+}
 
-#define cork_timestamp_init_nsec(ts, sec, nsec) \
-    do { \
-        *(ts) = (((uint64_t) (sec)) << 32) | \
-                ((((uint64_t) (nsec)) << 32) / 1000000000); \
-    } while (0)
+CORK_INLINE
+void
+cork_timestamp_init_nsec(cork_timestamp* ts, uint64_t sec, uint64_t nsec)
+{
+    *ts = (sec << 32) | ((nsec << 32) / 1000000000);
+}
 
 
 CORK_API void
 cork_timestamp_init_now(cork_timestamp *ts);
 
 
-#define cork_timestamp_sec(ts)  ((uint32_t) ((ts) >> 32))
-#define cork_timestamp_gsec(ts)  ((uint32_t) ((ts) & 0xffffffff))
+CORK_INLINE
+uint32_t
+cork_timestamp_sec(const cork_timestamp ts)
+{
+    return (uint32_t) (ts >> 32);
+}
 
-CORK_ATTR_UNUSED
-static inline uint64_t
+CORK_INLINE
+uint32_t
+cork_timestamp_gsec(const cork_timestamp ts)
+{
+    return (uint32_t) (ts & 0xffffffff);
+}
+
+CORK_INLINE
+uint64_t
 cork_timestamp_gsec_to_units(const cork_timestamp ts, uint64_t denom)
 {
     uint64_t  half = ((uint64_t) 1 << 31) / denom;
@@ -69,9 +86,26 @@ cork_timestamp_gsec_to_units(const cork_timestamp ts, uint64_t denom)
     return gsec;
 }
 
-#define cork_timestamp_msec(ts)  cork_timestamp_gsec_to_units(ts, 1000)
-#define cork_timestamp_usec(ts)  cork_timestamp_gsec_to_units(ts, 1000000)
-#define cork_timestamp_nsec(ts)  cork_timestamp_gsec_to_units(ts, 1000000000)
+CORK_INLINE
+uint64_t
+cork_timestamp_msec(const cork_timestamp ts)
+{
+    return cork_timestamp_gsec_to_units(ts, 1000);
+}
+
+CORK_INLINE
+uint64_t
+cork_timestamp_usec(const cork_timestamp ts)
+{
+    return cork_timestamp_gsec_to_units(ts, 1000000);
+}
+
+CORK_INLINE
+uint64_t
+cork_timestamp_nsec(const cork_timestamp ts)
+{
+    return cork_timestamp_gsec_to_units(ts, 1000000000);
+}
 
 
 CORK_API int

--- a/include/libcork/core/u128.h
+++ b/include/libcork/core/u128.h
@@ -42,8 +42,8 @@ typedef struct {
 
 
 /* i0-3 are given in big-endian order, regardless of host endianness */
-CORK_ATTR_UNUSED
-static cork_u128
+CORK_INLINE
+cork_u128
 cork_u128_from_32(uint32_t i0, uint32_t i1, uint32_t i2, uint32_t i3)
 {
     cork_u128  value;
@@ -62,8 +62,8 @@ cork_u128_from_32(uint32_t i0, uint32_t i1, uint32_t i2, uint32_t i3)
 }
 
 /* i0-1 are given in big-endian order, regardless of host endianness */
-CORK_ATTR_UNUSED
-static cork_u128
+CORK_INLINE
+cork_u128
 cork_u128_from_64(uint64_t i0, uint64_t i1)
 {
     cork_u128  value;
@@ -91,8 +91,8 @@ cork_u128_from_64(uint64_t i0, uint64_t i1)
 #endif
 
 
-CORK_ATTR_UNUSED
-static cork_u128
+CORK_INLINE
+cork_u128
 cork_u128_add(cork_u128 a, cork_u128 b)
 {
     cork_u128  result;
@@ -106,8 +106,8 @@ cork_u128_add(cork_u128 a, cork_u128 b)
     return result;
 }
 
-CORK_ATTR_UNUSED
-static cork_u128
+CORK_INLINE
+cork_u128
 cork_u128_sub(cork_u128 a, cork_u128 b)
 {
     cork_u128  result;
@@ -122,8 +122,8 @@ cork_u128_sub(cork_u128 a, cork_u128 b)
 }
 
 
-CORK_ATTR_UNUSED
-static bool
+CORK_INLINE
+bool
 cork_u128_eq(cork_u128 a, cork_u128 b)
 {
 #if CORK_U128_HAVE_U128
@@ -133,8 +133,8 @@ cork_u128_eq(cork_u128 a, cork_u128 b)
 #endif
 }
 
-CORK_ATTR_UNUSED
-static bool
+CORK_INLINE
+bool
 cork_u128_ne(cork_u128 a, cork_u128 b)
 {
 #if CORK_U128_HAVE_U128
@@ -144,8 +144,8 @@ cork_u128_ne(cork_u128 a, cork_u128 b)
 #endif
 }
 
-CORK_ATTR_UNUSED
-static bool
+CORK_INLINE
+bool
 cork_u128_lt(cork_u128 a, cork_u128 b)
 {
 #if CORK_U128_HAVE_U128
@@ -159,8 +159,8 @@ cork_u128_lt(cork_u128 a, cork_u128 b)
 #endif
 }
 
-CORK_ATTR_UNUSED
-static bool
+CORK_INLINE
+bool
 cork_u128_le(cork_u128 a, cork_u128 b)
 {
 #if CORK_U128_HAVE_U128
@@ -174,8 +174,8 @@ cork_u128_le(cork_u128 a, cork_u128 b)
 #endif
 }
 
-CORK_ATTR_UNUSED
-static bool
+CORK_INLINE
+bool
 cork_u128_gt(cork_u128 a, cork_u128 b)
 {
 #if CORK_U128_HAVE_U128
@@ -189,8 +189,8 @@ cork_u128_gt(cork_u128 a, cork_u128 b)
 #endif
 }
 
-CORK_ATTR_UNUSED
-static bool
+CORK_INLINE
+bool
 cork_u128_ge(cork_u128 a, cork_u128 b)
 {
 #if CORK_U128_HAVE_U128

--- a/include/libcork/ds/buffer.h
+++ b/include/libcork/ds/buffer.h
@@ -66,17 +66,25 @@ cork_buffer_truncate(struct cork_buffer *buffer, size_t length);
  * A whole bunch of methods for adding data
  */
 
-#define cork_buffer_copy(dest, src) \
-    (cork_buffer_set((dest), (src)->buf, (src)->size))
-
 CORK_API void
 cork_buffer_set(struct cork_buffer *buffer, const void *src, size_t length);
 
-#define cork_buffer_append_copy(dest, src) \
-    (cork_buffer_append((dest), (src)->buf, (src)->size))
+CORK_INLINE
+void
+cork_buffer_copy(struct cork_buffer* dest, const struct cork_buffer* src)
+{
+    cork_buffer_set(dest, src->buf, src->size);
+}
 
 CORK_API void
 cork_buffer_append(struct cork_buffer *buffer, const void *src, size_t length);
+
+CORK_INLINE
+void
+cork_buffer_append_copy(struct cork_buffer* dest, const struct cork_buffer* src)
+{
+    cork_buffer_append(dest, src->buf, src->size);
+}
 
 
 CORK_API void

--- a/include/libcork/ds/slice.h
+++ b/include/libcork/ds/slice.h
@@ -11,6 +11,7 @@
 #define LIBCORK_DS_SLICE_H
 
 #include <libcork/core/api.h>
+#include <libcork/core/attributes.h>
 #include <libcork/core/types.h>
 
 
@@ -79,57 +80,97 @@ struct cork_slice {
 CORK_API void
 cork_slice_clear(struct cork_slice *slice);
 
-#define cork_slice_is_empty(slice)  ((slice)->buf == NULL)
+CORK_INLINE
+bool
+cork_slice_is_empty(const struct cork_slice* slice)
+{
+    return slice->buf == NULL;
+}
 
 
 CORK_API int
 cork_slice_copy(struct cork_slice *dest, const struct cork_slice *slice,
                 size_t offset, size_t length);
 
-#define cork_slice_copy_fast(dest, slice, offset, length) \
-    ((slice)->iface->copy((dest), (slice), (offset), (length)))
+CORK_INLINE
+int
+cork_slice_copy_fast(struct cork_slice* dest, const struct cork_slice* slice,
+                     size_t offset, size_t length)
+{
+    return slice->iface->copy(dest, slice, offset, length);
+}
 
 CORK_API int
 cork_slice_copy_offset(struct cork_slice *dest, const struct cork_slice *slice,
                        size_t offset);
 
-#define cork_slice_copy_offset_fast(dest, slice, offset) \
-    ((slice)->iface->copy \
-     ((dest), (slice), (offset), (slice)->size - (offset)))
+CORK_INLINE
+int
+cork_slice_copy_offset_fast(struct cork_slice *dest,
+                            const struct cork_slice *slice, size_t offset)
+{
+    return slice->iface->copy(dest, slice, offset, slice->size - offset);
+}
 
 
 CORK_API int
 cork_slice_light_copy(struct cork_slice *dest, const struct cork_slice *slice,
                       size_t offset, size_t length);
 
-#define cork_slice_light_copy_fast(dest, slice, offset, length) \
-    ((slice)->iface->light_copy((dest), (slice), (offset), (length)))
+CORK_INLINE
+int
+cork_slice_light_copy_fast(struct cork_slice *dest,
+                           const struct cork_slice *slice, size_t offset,
+                           size_t length)
+{
+    return slice->iface->light_copy(dest, slice, offset, length);
+}
 
 CORK_API int
 cork_slice_light_copy_offset(struct cork_slice *dest,
                              const struct cork_slice *slice, size_t offset);
 
-#define cork_slice_light_copy_offset_fast(dest, slice, offset) \
-    ((slice)->iface->light_copy \
-     ((dest), (slice), (offset), (slice)->size - (offset)))
+CORK_INLINE
+int
+cork_slice_light_copy_offset_fast(struct cork_slice *dest,
+                                  const struct cork_slice *slice,
+                                  size_t offset)
+{
+    return slice->iface->light_copy(dest, slice, offset, slice->size - offset);
+}
 
 
 CORK_API int
 cork_slice_slice(struct cork_slice *slice, size_t offset, size_t length);
 
-#define cork_slice_slice_fast(_slice, offset, length) \
-    ((_slice)->iface->slice == NULL? \
-     ((_slice)->buf += (offset), (_slice)->size = (length), 0): \
-     ((_slice)->iface->slice((_slice), (offset), (length))))
+CORK_INLINE
+int
+cork_slice_slice_fast(struct cork_slice *slice, size_t offset, size_t length)
+{
+    if (slice->iface->slice == NULL) {
+        slice->buf += offset;
+        slice->size = length;
+        return 0;
+    } else {
+        return slice->iface->slice(slice, offset, length);
+    }
+}
 
 CORK_API int
 cork_slice_slice_offset(struct cork_slice *slice, size_t offset);
 
-#define cork_slice_slice_offset_fast(_slice, offset) \
-    ((_slice)->iface->slice == NULL? \
-     ((_slice)->buf += (offset), (_slice)->size -= (offset), 0): \
-     ((_slice)->iface->slice \
-      ((_slice), (offset), (_slice)->size - (offset))))
+CORK_INLINE
+int
+cork_slice_slice_offset_fast(struct cork_slice *slice, size_t offset)
+{
+    if (slice->iface->slice == NULL) {
+        slice->buf += offset;
+        slice->size -= offset;
+        return 0;
+    } else {
+        return slice->iface->slice(slice, offset, slice->size - offset);
+    }
+}
 
 
 CORK_API void

--- a/include/libcork/ds/stream.h
+++ b/include/libcork/ds/stream.h
@@ -13,6 +13,7 @@
 #include <stdio.h>
 
 #include <libcork/core/api.h>
+#include <libcork/core/attributes.h>
 #include <libcork/core/types.h>
 
 
@@ -29,14 +30,27 @@ struct cork_stream_consumer {
 };
 
 
-#define cork_stream_consumer_data(consumer, buf, size, is_first) \
-    ((consumer)->data((consumer), (buf), (size), (is_first)))
+CORK_INLINE
+int
+cork_stream_consumer_data(struct cork_stream_consumer* consumer,
+                          const void *buf, size_t size, bool is_first_chunk)
+{
+    return consumer->data(consumer, buf, size, is_first_chunk);
+}
 
-#define cork_stream_consumer_eof(consumer) \
-    ((consumer)->eof((consumer)))
+CORK_INLINE
+int
+cork_stream_consumer_eof(struct cork_stream_consumer *consumer)
+{
+    return consumer->eof(consumer);
+}
 
-#define cork_stream_consumer_free(consumer) \
-    ((consumer)->free((consumer)))
+CORK_INLINE
+void
+cork_stream_consumer_free(struct cork_stream_consumer *consumer)
+{
+    consumer->free(consumer);
+}
 
 
 CORK_API int

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,7 @@ add_c_library(
         libcork/core/error.c
         libcork/core/gc.c
         libcork/core/hash.c
+        libcork/core/id.c
         libcork/core/ip-address.c
         libcork/core/mempool.c
         libcork/core/timestamp.c
@@ -59,6 +60,7 @@ add_c_library(
         libcork/ds/managed-buffer.c
         libcork/ds/ring-buffer.c
         libcork/ds/slice.c
+        libcork/ds/stream.c
         libcork/posix/directory-walker.c
         libcork/posix/env.c
         libcork/posix/exec.c

--- a/src/libcork/core/allocator.c
+++ b/src/libcork/core/allocator.c
@@ -419,3 +419,80 @@ cork_debug_alloc_new(const struct cork_alloc *parent)
     cork_alloc_set_free(debug, cork_debug_alloc__free);
     return debug;
 }
+
+/*-----------------------------------------------------------------------
+ * Inline declarations
+ */
+
+void *
+cork_alloc_calloc(const struct cork_alloc *alloc, size_t count, size_t size);
+
+void *
+cork_alloc_malloc(const struct cork_alloc *alloc, size_t size);
+
+void *
+cork_alloc_realloc(const struct cork_alloc *alloc, void *ptr,
+                   size_t old_size, size_t new_size);
+
+void *
+cork_alloc_xcalloc(const struct cork_alloc *alloc, size_t count, size_t size);
+
+void *
+cork_alloc_xmalloc(const struct cork_alloc *alloc, size_t size);
+
+void *
+cork_alloc_xrealloc(const struct cork_alloc *alloc, void *ptr,
+                    size_t old_size, size_t new_size);
+
+void *
+cork_alloc_xreallocf(const struct cork_alloc *alloc, void *ptr,
+                     size_t old_size, size_t new_size);
+
+void
+cork_alloc_free(const struct cork_alloc *alloc, void *ptr, size_t size);
+
+void
+cork_alloc_cfree(const struct cork_alloc *alloc, void *ptr,
+                 size_t count, size_t size);
+
+void *
+cork_calloc(size_t count, size_t size);
+
+void *
+cork_malloc(size_t size);
+
+void *
+cork_realloc(void *ptr, size_t old_size, size_t new_size);
+
+void *
+cork_xcalloc(size_t count, size_t size);
+
+void *
+cork_xmalloc(size_t size);
+
+void *
+cork_xrealloc(void *ptr, size_t old_size, size_t new_size);
+
+void *
+cork_xreallocf(void *ptr, size_t old_size, size_t new_size);
+
+void
+cork_free(void *ptr, size_t size);
+
+void
+cork_cfree(void *ptr, size_t count, size_t size);
+
+const char *
+cork_strdup(const char *str);
+
+const char *
+cork_strndup(const char *str, size_t size);
+
+const char *
+cork_xstrdup(const char *str);
+
+const char *
+cork_xstrndup(const char *str, size_t size);
+
+void
+cork_strfree(const char *str);

--- a/src/libcork/core/error.c
+++ b/src/libcork/core/error.c
@@ -244,3 +244,11 @@ cork_unknown_error_set_(const char *location)
 {
     cork_error_set_printf(CORK_UNKNOWN_ERROR, "Unknown error in %s", location);
 }
+
+/*-----------------------------------------------------------------------
+ * Inline declarations
+ */
+
+void *
+cork_abort_if_null_(void *ptr, const char *msg, const char *func,
+                    const char *file, unsigned int line);

--- a/src/libcork/core/hash.c
+++ b/src/libcork/core/hash.c
@@ -7,13 +7,17 @@
  * ----------------------------------------------------------------------
  */
 
-#define CORK_HASH_ATTRIBUTES  CORK_API
-
 #include "libcork/core/hash.h"
 #include "libcork/core/types.h"
 
-/* All of the following functions will be defined for us by libcork/core/hash.h:
- *   cork_hash_buffer
- *   cork_big_hash_buffer
- *   cork_stable_hash_buffer
- */
+bool
+cork_big_hash_equal(const cork_big_hash h1, const cork_big_hash h2);
+
+cork_hash
+cork_stable_hash_buffer(cork_hash seed, const void *src, size_t len);
+
+cork_hash
+cork_hash_buffer(cork_hash seed, const void *src, size_t len);
+
+cork_big_hash
+cork_big_hash_buffer(cork_big_hash seed, const void *src, size_t len);

--- a/src/libcork/core/id.c
+++ b/src/libcork/core/id.c
@@ -1,0 +1,23 @@
+/* -*- coding: utf-8 -*-
+ * ----------------------------------------------------------------------
+ * Copyright © 2020, libcork authors
+ * All rights reserved.
+ *
+ * Please see the COPYING file in this distribution for license details.
+ * ----------------------------------------------------------------------
+ */
+
+#include "libcork/core/id.h"
+
+/*-----------------------------------------------------------------------
+ * Inline declarations
+ */
+
+bool
+cork_uid_equal(const cork_uid id1, const cork_uid id2);
+
+cork_hash
+cork_uid_hash(const cork_uid id);
+
+const char*
+cork_uid_name(const cork_uid id);

--- a/src/libcork/core/ip-address.c
+++ b/src/libcork/core/ip-address.c
@@ -534,3 +534,28 @@ cork_ip_is_valid_network(const struct cork_ip *addr, unsigned int cidr_prefix)
             return false;
     }
 }
+
+/*-----------------------------------------------------------------------
+ * Inline declarations
+ */
+
+void
+cork_ipv4_copy(struct cork_ipv4* addr, const void* src);
+
+bool
+cork_ipv4_equal(const struct cork_ipv4* addr1, const struct cork_ipv4* addr2);
+
+void
+cork_ipv6_copy(struct cork_ipv6* addr, const void* src);
+
+bool
+cork_ipv6_equal(const struct cork_ipv6* addr1, const struct cork_ipv6* addr2);
+
+bool
+cork_ip_equal(const struct cork_ip* addr1, const struct cork_ip* addr2);
+
+void
+cork_ip_from_ipv4(struct cork_ip* addr, const void* src);
+
+void
+cork_ip_from_ipv6(struct cork_ip* addr, const void* src);

--- a/src/libcork/core/mempool.c
+++ b/src/libcork/core/mempool.c
@@ -196,3 +196,10 @@ cork_mempool_free_object(struct cork_mempool *mp, void *ptr)
     mp->free_list = obj;
     mp->allocated_count--;
 }
+
+/*-----------------------------------------------------------------------
+ * Inline declarations
+ */
+
+struct cork_mempool*
+cork_mempool_new_size(size_t element_size);

--- a/src/libcork/core/timestamp.c
+++ b/src/libcork/core/timestamp.c
@@ -160,3 +160,40 @@ cork_timestamp_format_local(const cork_timestamp ts, const char *format,
     localtime_r(&clock, &tm);
     return cork_timestamp_format_parts(ts, &tm, format, dest);
 }
+
+/*-----------------------------------------------------------------------
+ * Inline declarations
+ */
+
+void
+cork_timestamp_init_sec(cork_timestamp* ts, uint64_t sec);
+
+void
+cork_timestamp_init_gsec(cork_timestamp* ts, uint64_t sec, uint64_t gsec);
+
+void
+cork_timestamp_init_msec(cork_timestamp* ts, uint64_t sec, uint64_t msec);
+
+void
+cork_timestamp_init_usec(cork_timestamp* ts, uint64_t sec, uint64_t usec);
+
+void
+cork_timestamp_init_nsec(cork_timestamp* ts, uint64_t sec, uint64_t nsec);
+
+uint32_t
+cork_timestamp_sec(const cork_timestamp ts);
+
+uint32_t
+cork_timestamp_gsec(const cork_timestamp ts);
+
+uint64_t
+cork_timestamp_gsec_to_units(const cork_timestamp ts, uint64_t denom);
+
+uint64_t
+cork_timestamp_msec(const cork_timestamp ts);
+
+uint64_t
+cork_timestamp_usec(const cork_timestamp ts);
+
+uint64_t
+cork_timestamp_nsec(const cork_timestamp ts);

--- a/src/libcork/core/u128.c
+++ b/src/libcork/core/u128.c
@@ -83,3 +83,37 @@ cork_u128_to_padded_hex(char *buf, cork_u128 val)
     snprintf(buf, CORK_U128_HEX_LENGTH, "%016" PRIx64 "%016" PRIx64, hi, lo);
     return buf;
 }
+
+/*-----------------------------------------------------------------------
+ * Inline declarations
+ */
+
+cork_u128
+cork_u128_from_32(uint32_t i0, uint32_t i1, uint32_t i2, uint32_t i3);
+
+cork_u128
+cork_u128_from_64(uint64_t i0, uint64_t i1);
+
+cork_u128
+cork_u128_add(cork_u128 a, cork_u128 b);
+
+cork_u128
+cork_u128_sub(cork_u128 a, cork_u128 b);
+
+bool
+cork_u128_eq(cork_u128 a, cork_u128 b);
+
+bool
+cork_u128_ne(cork_u128 a, cork_u128 b);
+
+bool
+cork_u128_lt(cork_u128 a, cork_u128 b);
+
+bool
+cork_u128_le(cork_u128 a, cork_u128 b);
+
+bool
+cork_u128_gt(cork_u128 a, cork_u128 b);
+
+bool
+cork_u128_ge(cork_u128 a, cork_u128 b);

--- a/src/libcork/ds/slice.c
+++ b/src/libcork/ds/slice.c
@@ -294,3 +294,34 @@ cork_slice_init_copy_once(struct cork_slice *dest, const void *buf, size_t size)
     dest->iface = &cork_copy_once_slice;
     dest->user_data = NULL;
 }
+
+/*-----------------------------------------------------------------------
+ * Inline declarations
+ */
+
+bool
+cork_slice_is_empty(const struct cork_slice* slice);
+
+int
+cork_slice_copy_fast(struct cork_slice* dest, const struct cork_slice* slice,
+                     size_t offset, size_t length);
+
+int
+cork_slice_copy_offset_fast(struct cork_slice *dest,
+                            const struct cork_slice *slice, size_t offset);
+
+int
+cork_slice_light_copy_fast(struct cork_slice *dest,
+                           const struct cork_slice *slice, size_t offset,
+                           size_t length);
+
+int
+cork_slice_light_copy_offset_fast(struct cork_slice *dest,
+                                  const struct cork_slice *slice,
+                                  size_t offset);
+
+int
+cork_slice_slice_fast(struct cork_slice *slice, size_t offset, size_t length);
+
+int
+cork_slice_slice_offset_fast(struct cork_slice *slice, size_t offset);

--- a/src/libcork/ds/stream.c
+++ b/src/libcork/ds/stream.c
@@ -1,0 +1,24 @@
+/* -*- coding: utf-8 -*-
+ * ----------------------------------------------------------------------
+ * Copyright © 2020, libcork authors
+ * All rights reserved.
+ *
+ * Please see the COPYING file in this distribution for license details.
+ * ----------------------------------------------------------------------
+ */
+
+#include "libcork/ds/stream.h"
+
+/*-----------------------------------------------------------------------
+ * Inline declarations
+ */
+
+int
+cork_stream_consumer_data(struct cork_stream_consumer* consumer,
+                          const void *buf, size_t size, bool is_first_chunk);
+
+int
+cork_stream_consumer_eof(struct cork_stream_consumer *consumer);
+
+void
+cork_stream_consumer_free(struct cork_stream_consumer *consumer);

--- a/tests/test-buffer.c
+++ b/tests/test-buffer.c
@@ -345,3 +345,14 @@ main(int argc, const char **argv)
 
     return (number_failed == 0)? EXIT_SUCCESS: EXIT_FAILURE;
 }
+
+/*-----------------------------------------------------------------------
+ * Inline declarations
+ */
+
+void
+cork_buffer_copy(struct cork_buffer* dest, const struct cork_buffer* src);
+
+void
+cork_buffer_append_copy(struct cork_buffer* dest,
+                        const struct cork_buffer* src);


### PR DESCRIPTION
Ideally, we use the C99 `inline` attribute — you provide a declaration _and_ definition of your function in a header file, labeled with the new CORK_INLINE attribute.  You then provide a copy of the declaration (but _not_ the definition) in a source file, _without_ the CORK_INLINE attribute.  That ensures that there's a linkable copy of the function as part of that source file — and that its definition is guaranteed to match the one in the header file.

If C99 inline isn't available, we fall back on using `static`.  That means that the function definition will be duplicated in each source file that uses it, but prevents duplicate symbol definition errors.  (That means you can't rely on being able to take the address of the inline function, in a way that's consistent across source files, unless you can guarantee that you're compiling in C99 mode.)

This patch also updates a lot of libcork functions and macros to use the new attribute.