### PR TITLE
Fix autotools-driven install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ endif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
 find_package(Threads)
 set(THREADS_LDFLAGS "${CMAKE_THREAD_LIBS_INIT}")
 set(THREADS_STATIC_LDFLAGS "${CMAKE_THREAD_LIBS_INIT}")
+set(PTHREAD_LIBS "${CMAKE_THREAD_LIBS_INIT}")
 
 #-----------------------------------------------------------------------
 # Include our subdirectories

--- a/Makefile.am
+++ b/Makefile.am
@@ -147,6 +147,8 @@ libcork_la_SOURCES = \
     src/libcork/posix/subprocess.c \
     src/libcork/pthreads/thread.c
 
+pkgconfig_DATA = src/libcork.pc
+
 libcork_la_CPPFLAGS = $(AM_CPPFLAGS) $(CPPFLAGS) -DCORK_API=CORK_EXPORT
 libcork_la_CFLAGS = $(AM_CFLAGS) $(CFLAGS) -DCORK_API=CORK_EXPORT
 libcork_la_LDFLAGS = $(AM_LDFLAGS) $(LDFLAGS) -version-info 16:3:0

--- a/Makefile.am
+++ b/Makefile.am
@@ -73,7 +73,8 @@ config_include_HEADERS = \
     include/libcork/config/macosx.h \
     include/libcork/config/bsd.h \
     include/libcork/config/linux.h \
-    include/libcork/config/config.h
+    include/libcork/config/config.h \
+    include/libcork/config/version.h
 
 core_include_HEADERS = \
     include/libcork/core/hash.h \

--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,7 @@ CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
 CC="$PTHREAD_CC"
 
 # pkg-config
+PKG_INSTALLDIR
 AC_CONFIG_FILES([src/libcork.pc])
 
 # Tests

--- a/src/libcork.pc.in
+++ b/src/libcork.pc.in
@@ -12,5 +12,5 @@ Description: A simple, easily embeddable cross-platform C library
 Version: @VERSION@
 URL: https://libcork.io/
 Libs: -L${libdir} -lcork
-Libs.private: @CMAKE_THREAD_LIBS_INIT@
-Cflags: -I${includedir}
+Libs.private: @PTHREAD_LIBS@
+Cflags: -I${includedir} @PTHREAD_CFLAGS@


### PR DESCRIPTION
There were a couple of files not being installed by the autotools build scripts.  (The CMake scripts were installing them just fine.)