### PR TITLE
Add byte-swapping macros for cork_u128

### DIFF
--- a/docs/old/byte-order.rst
+++ b/docs/old/byte-order.rst
@@ -61,6 +61,7 @@ value of the macro.
 .. function:: uint16_t CORK_SWAP_UINT16(uint16_t value)
               uint32_t CORK_SWAP_UINT32(uint32_t value)
               uint64_t CORK_SWAP_UINT64(uint64_t value)
+              cork_u128 CORK_SWAP_UINT128(cork_128 value)
 
    These functions always perform a byte-swap, regardless of the
    endianness of the host system.
@@ -68,6 +69,7 @@ value of the macro.
 .. function:: uint16_t CORK_UINT16_BIG_TO_HOST(uint16_t value)
               uint32_t CORK_UINT32_BIG_TO_HOST(uint32_t value)
               uint64_t CORK_UINT64_BIG_TO_HOST(uint64_t value)
+              cork_u128 CORK_UINT128_BIG_TO_HOST(cork_u128 value)
 
    These functions convert a big-endian (or network-endian) value into
    host endianness.  (I.e., they only perform a swap if the current host
@@ -76,6 +78,7 @@ value of the macro.
 .. function:: uint16_t CORK_UINT16_HOST_TO_BIG(uint16_t value)
               uint32_t CORK_UINT32_HOST_TO_BIG(uint32_t value)
               uint64_t CORK_UINT64_HOST_TO_BIG(uint64_t value)
+              cork_u128 CORK_UINT128_HOST_TO_BIG(cork_u128 value)
 
    These functions convert a host-endian value into big (or network)
    endianness.  (I.e., they only perform a swap if the current host is
@@ -84,6 +87,7 @@ value of the macro.
 .. function:: uint16_t CORK_UINT16_LITTLE_TO_HOST(uint16_t value)
               uint32_t CORK_UINT32_LITTLE_TO_HOST(uint32_t value)
               uint64_t CORK_UINT64_LITTLE_TO_HOST(uint64_t value)
+              cork_u128 CORK_UINT128_LITTLE_TO_HOST(cork_u128 value)
 
    These functions convert a little-endian value into host endianness.
    (I.e., they only perform a swap if the current host is big-endian.)
@@ -91,6 +95,7 @@ value of the macro.
 .. function:: uint16_t CORK_UINT16_HOST_TO_LITTLE(uint16_t value)
               uint32_t CORK_UINT32_HOST_TO_LITTLE(uint32_t value)
               uint64_t CORK_UINT64_HOST_TO_LITTLE(uint64_t value)
+              cork_u128 CORK_UINT128_HOST_TO_LITTLE(cork_u128 value)
 
    These functions convert a host-endian value into little endianness.
    (I.e., they only perform a swap if the current host is big-endian.)
@@ -108,6 +113,7 @@ a reference to the variable to be swapped.)
 .. function:: void CORK_SWAP_UINT16_IN_PLACE(uint16_t &value)
               void CORK_SWAP_UINT32_IN_PLACE(uint32_t &value)
               void CORK_SWAP_UINT64_IN_PLACE(uint64_t &value)
+              void CORK_SWAP_UINT128_IN_PLACE(cork_u128 &value)
 
    These functions always perform a byte-swap, regardless of the
    endianness of the host system.
@@ -115,6 +121,7 @@ a reference to the variable to be swapped.)
 .. function:: void CORK_UINT16_BIG_TO_HOST_IN_PLACE(uint16_t &value)
               void CORK_UINT32_BIG_TO_HOST_IN_PLACE(uint32_t &value)
               void CORK_UINT64_BIG_TO_HOST_IN_PLACE(uint64_t &value)
+              void CORK_UINT128_BIG_TO_HOST_IN_PLACE(cork_u128 &value)
 
    These functions convert a big-endian (or network-endian) value into
    host endianness, and vice versa.  (I.e., they only perform a swap if
@@ -123,6 +130,7 @@ a reference to the variable to be swapped.)
 .. function:: void CORK_UINT16_HOST_TO_BIG_IN_PLACE(uint16_t &value)
               void CORK_UINT32_HOST_TO_BIG_IN_PLACE(uint32_t &value)
               void CORK_UINT64_HOST_TO_BIG_IN_PLACE(uint64_t &value)
+              void CORK_UINT128_HOST_TO_BIG_IN_PLACE(cork_u128 &value)
 
    These functions convert a host-endian value into big (or network)
    endianness.  (I.e., they only perform a swap if the current host is
@@ -131,6 +139,7 @@ a reference to the variable to be swapped.)
 .. function:: void CORK_UINT16_LITTLE_TO_HOST_IN_PLACE(uint16_t &value)
               void CORK_UINT32_LITTLE_TO_HOST_IN_PLACE(uint32_t &value)
               void CORK_UINT64_LITTLE_TO_HOST_IN_PLACE(uint64_t &value)
+              void CORK_UINT128_LITTLE_TO_HOST_IN_PLACE(cork_u128 &value)
 
    These functions convert a little-endian value into host endianness, and
    vice versa.  (I.e., they only perform a swap if the current host is
@@ -139,6 +148,7 @@ a reference to the variable to be swapped.)
 .. function:: void CORK_UINT16_HOST_TO_LITTLE_IN_PLACE(uint16_t &value)
               void CORK_UINT32_HOST_TO_LITTLE_IN_PLACE(uint32_t &value)
               void CORK_UINT64_HOST_TO_LITTLE_IN_PLACE(uint64_t &value)
+              void CORK_UINT128_HOST_TO_LITTLE_IN_PLACE(cork_u128 &value)
 
    These functions convert a host-endian value into little endianness.
    (I.e., they only perform a swap if the current host is big-endian.)

--- a/include/libcork/core/u128.h
+++ b/include/libcork/core/u128.h
@@ -97,6 +97,35 @@ cork_u128_zero(void)
 #define cork_u128_be64(val, idx)  ((val)._.u64[1 - (idx)])
 #endif
 
+#define CORK_SWAP_UINT128(__u128)                                              \
+  (cork_u128_from_64(CORK_SWAP_UINT64(cork_u128_be64((__u128), 1)),            \
+                     CORK_SWAP_UINT64(cork_u128_be64((__u128), 0))))
+
+#define CORK_SWAP_IN_PLACE_UINT128(__u128) \
+    do { \
+        (__u128) = CORK_SWAP_UINT128(__u128); \
+    } while (0)
+
+#if CORK_HOST_ENDIANNESS == CORK_BIG_ENDIAN
+#define CORK_UINT128_BIG_TO_HOST(__u128) (__u128) /* nothing to do */
+#define CORK_UINT128_LITTLE_TO_HOST(__u128)  CORK_SWAP_UINT128(__u128)
+#define CORK_UINT128_BIG_TO_HOST_IN_PLACE(__u128) /* nothing to do */
+#define CORK_UINT128_LITTLE_TO_HOST_IN_PLACE(__u128)                           \
+  CORK_SWAP_IN_PLACE_UINT128(__u128)
+#elif CORK_HOST_ENDIANNESS == CORK_LITTLE_ENDIAN
+#define CORK_UINT128_BIG_TO_HOST(__u128)  CORK_SWAP_UINT128(__u128)
+#define CORK_UINT128_LITTLE_TO_HOST(__u128) (__u128) /* nothing to do */
+#define CORK_UINT128_BIG_TO_HOST_IN_PLACE(__u128)                              \
+  CORK_SWAP_IN_PLACE_UINT128(__u128)
+#define CORK_UINT128_LITTLE_TO_HOST_IN_PLACE(__u128) /* nothing to do */
+#endif
+
+#define CORK_UINT128_HOST_TO_BIG(__u128) CORK_UINT128_BIG_TO_HOST(__u128)
+#define CORK_UINT128_HOST_TO_LITTLE(__u128) CORK_UINT128_LITTLE_TO_HOST(__u128)
+#define CORK_UINT128_HOST_TO_BIG_IN_PLACE(__u128)                              \
+  CORK_UINT128_BIG_TO_HOST_IN_PLACE(__u128)
+#define CORK_UINT128_HOST_TO_LITTLE_IN_PLACE(__u128)                           \
+  CORK_UINT128_LITTLE_TO_HOST_IN_PLACE(__u128)
 
 CORK_INLINE
 bool

--- a/tests/test-core.c
+++ b/tests/test-core.c
@@ -143,6 +143,11 @@ END_TEST
  * Endianness
  */
 
+#define uint8_t_eq(a, b) ((a) == (b))
+#define uint16_t_eq(a, b) ((a) == (b))
+#define uint32_t_eq(a, b) ((a) == (b))
+#define uint64_t_eq(a, b) ((a) == (b))
+
 START_TEST(test_endianness)
 {
 #define TEST_ENDIAN(TYPE, type, sz, expected, ...) \
@@ -151,21 +156,21 @@ START_TEST(test_endianness)
             { { __VA_ARGS__ } }; \
         \
         type  from_big = CORK_##TYPE##_BIG_TO_HOST(u.val); \
-        fail_unless(from_big == expected, \
+        fail_unless(type##_eq(from_big, expected), \
                     "Unexpected big-to-host " #type " value"); \
         \
         type  from_big_in_place = u.val; \
         CORK_##TYPE##_BIG_TO_HOST_IN_PLACE(from_big_in_place); \
-        fail_unless(from_big_in_place == expected, \
+        fail_unless(type##_eq(from_big_in_place, expected), \
                     "Unexpected in-place big-to-host " #type " value"); \
         \
         type  to_big = CORK_##TYPE##_HOST_TO_BIG(expected); \
-        fail_unless(to_big == u.val, \
+        fail_unless(type##_eq(to_big, u.val), \
                     "Unexpected host-to-big " #type " value"); \
         \
         type  to_big_in_place = expected; \
         CORK_##TYPE##_HOST_TO_BIG_IN_PLACE(to_big_in_place); \
-        fail_unless(to_big_in_place == u.val, \
+        fail_unless(type##_eq(to_big_in_place, u.val), \
                     "Unexpected in-place host-to-big " #type " value"); \
         \
         int  i; \
@@ -176,21 +181,21 @@ START_TEST(test_endianness)
         } \
         \
         type  from_little = CORK_##TYPE##_LITTLE_TO_HOST(u.val); \
-        fail_unless(from_little == expected, \
+        fail_unless(type##_eq(from_little, expected), \
                     "Unexpected little-to-host " #type " value"); \
         \
         type  from_little_in_place = u.val; \
         CORK_##TYPE##_LITTLE_TO_HOST_IN_PLACE(from_little_in_place); \
-        fail_unless(from_little_in_place == expected, \
+        fail_unless(type##_eq(from_little_in_place, expected), \
                     "Unexpected in-place little-to-host " #type " value"); \
         \
         type  to_little = CORK_##TYPE##_HOST_TO_LITTLE(expected); \
-        fail_unless(to_little == u.val, \
+        fail_unless(type##_eq(to_little, u.val), \
                     "Unexpected host-to-little " #type " value"); \
         \
         type  to_little_in_place = expected; \
         CORK_##TYPE##_HOST_TO_LITTLE_IN_PLACE(to_little_in_place); \
-        fail_unless(to_little_in_place == u.val, \
+        fail_unless(type##_eq(to_little_in_place, u.val), \
                     "Unexpected in-place host-to-little " #type " value"); \
     }
 
@@ -198,6 +203,10 @@ START_TEST(test_endianness)
     TEST_ENDIAN(UINT32, uint32_t, 4, 0x01020304, 1, 2, 3, 4);
     TEST_ENDIAN(UINT64, uint64_t, 8, UINT64_C(0x0102030405060708),
                 1, 2, 3, 4, 5, 6, 7, 8);
+    TEST_ENDIAN(
+        UINT128, cork_u128, 16,
+        cork_u128_from_32(0x01020304, 0x05060708, 0x090a0b0c, 0x0d0e0f00), 1, 2,
+        3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0);
 
 #undef TEST_ENDIAN
 }


### PR DESCRIPTION
Basically a bunch of copy/paste.  The test cases for the other types work with only slight modifications for `cork_u128`.  (Basically, just a small workaround to deal with the fact that you can't compare `cork_u128`s with `==`.)