### PR TITLE
Add cork_slice_advance function

### DIFF
--- a/include/libcork/ds/slice.h
+++ b/include/libcork/ds/slice.h
@@ -147,7 +147,7 @@ CORK_INLINE
 int
 cork_slice_slice_fast(struct cork_slice *slice, size_t offset, size_t length)
 {
-    if (slice->iface->slice == NULL) {
+    if (CORK_LIKELY(slice->iface->slice == NULL)) {
         slice->buf += offset;
         slice->size = length;
         return 0;
@@ -163,7 +163,7 @@ CORK_INLINE
 int
 cork_slice_slice_offset_fast(struct cork_slice *slice, size_t offset)
 {
-    if (slice->iface->slice == NULL) {
+    if (CORK_LIKELY(slice->iface->slice == NULL)) {
         slice->buf += offset;
         slice->size -= offset;
         return 0;

--- a/include/libcork/ds/slice.h
+++ b/include/libcork/ds/slice.h
@@ -172,6 +172,28 @@ cork_slice_slice_offset_fast(struct cork_slice *slice, size_t offset)
     }
 }
 
+CORK_API const void*
+cork_slice_advance_checked(struct cork_slice* slice, size_t offset);
+
+CORK_INLINE
+const void*
+cork_slice_advance(struct cork_slice* slice, size_t offset)
+{
+    if (CORK_LIKELY(slice->iface->slice == NULL)) {
+        const void* buf = slice->buf;
+        slice->buf += offset;
+        slice->size -= offset;
+        return buf;
+    } else {
+        const void* buf = slice->buf;
+        int rc = slice->iface->slice(slice, offset, slice->size - offset);
+        if (CORK_UNLIKELY(rc != 0)) {
+            return NULL;
+        }
+        return buf;
+    }
+}
+
 
 CORK_API void
 cork_slice_finish(struct cork_slice *slice);

--- a/src/libcork/ds/slice.c
+++ b/src/libcork/ds/slice.c
@@ -182,6 +182,20 @@ cork_slice_slice_offset(struct cork_slice *slice, size_t offset)
 }
 
 
+const void*
+cork_slice_advance_checked(struct cork_slice* slice, size_t offset)
+{
+    if (slice == NULL) {
+        cork_slice_invalid_slice_set(0, offset, 0);
+        return NULL;
+    } else {
+        const void* buf = slice->buf;
+        rpi_check(cork_slice_slice(slice, offset, slice->size - offset));
+        return buf;
+    }
+}
+
+
 void
 cork_slice_finish(struct cork_slice *slice)
 {
@@ -325,3 +339,6 @@ cork_slice_slice_fast(struct cork_slice *slice, size_t offset, size_t length);
 
 int
 cork_slice_slice_offset_fast(struct cork_slice *slice, size_t offset);
+
+const void*
+cork_slice_advance(struct cork_slice *slice, size_t offset);

--- a/tests/test-slice.c
+++ b/tests/test-slice.c
@@ -28,9 +28,15 @@ START_TEST(test_static_slice)
     size_t  SRC_LEN = sizeof(SRC) - 1;
 
     struct cork_slice  slice;
+    struct cork_slice  advanced;
+    const void* original;
     struct cork_slice  copy1;
     struct cork_slice  lcopy1;
     cork_slice_init_static(&slice, SRC, SRC_LEN);
+    fail_if_error(cork_slice_copy_offset(&advanced, &slice, 0));
+    fail_if_error(original = cork_slice_advance(&advanced, 4));
+    fail_unless(strcmp(SRC, original) == 0,
+                "Advance should return original buffer");
     fail_if_error(cork_slice_copy(&copy1, &slice, 8, 4));
     fail_if_error(cork_slice_light_copy(&lcopy1, &slice, 8, 4));
     fail_if_error(cork_slice_slice(&slice, 8, 4));
@@ -40,6 +46,7 @@ START_TEST(test_static_slice)
     cork_slice_finish(&lcopy1);
     cork_slice_finish(&slice);
     cork_slice_finish(&copy1);
+    cork_slice_finish(&advanced);
 }
 END_TEST
 


### PR DESCRIPTION
This is exactly like `cork_slice_slice_offset`, except that it returns the slice's buffer from _before_ the call.