### PR TITLE
Rebuild autotools scripts correctly in CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,9 @@ find_package(CTargets)
 
 execute_process(
     COMMAND
-      ${CMAKE_CURRENT_SOURCE_DIR}/build-aux/calculate version .version-stamp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_SOURCE_DIR}/build-aux/calculate version
+        ${CMAKE_SOURCE_DIR} .version-stamp
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     RESULT_VARIABLE VERSION_RESULT
     OUTPUT_VARIABLE VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -44,8 +45,9 @@ endif(BASE_VERSION MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(-dev)?$")
 
 execute_process(
     COMMAND
-      ${CMAKE_CURRENT_SOURCE_DIR}/build-aux/calculate commit .commit-stamp
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      ${CMAKE_SOURCE_DIR}/build-aux/calculate commit
+        ${CMAKE_SOURCE_DIR} .commit-stamp
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     RESULT_VARIABLE GIT_SHA1_RESULT
     OUTPUT_VARIABLE GIT_SHA1
     OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,17 +14,15 @@ dist-hook: dist-check-git-version dist-stamps
 
 dist-check-git-version:
 	: # Verify that the version that configure.ac recorded matches the
-	: # current version from git tags.
-	@if test -n $(top_srcdir)/.version-stamp; then \
-	    git_ver=`$(top_srcdir)/build-aux/calculate version`; \
-	    if test "x$${git_ver}" != "x$(PACKAGE_VERSION)"; then \
-	        echo "ERROR: PACKAGE_VERSION and 'git describe' version do not match:"; \
-	        echo "     current 'git describe' version: $${git_ver}"; \
-	        echo "     current PACKAGE_VERSION:        $(PACKAGE_VERSION)"; \
-	        echo "Update PACKAGE_VERSION by running $(top_srcdir)/autogen.sh."; \
-	        rm -rf "$(top_srcdir)/autom4te.cache"; \
-	        exit 1; \
-	    fi \
+	: # current calculated version.
+	@git_ver=`$(top_srcdir)/build-aux/calculate version $(top_srcdir) $(top_srcdir)/.version-stamp`; \
+	if test "x$${git_ver}" != "x$(PACKAGE_VERSION)"; then \
+	    echo "ERROR: PACKAGE_VERSION and 'git describe' version do not match:"; \
+	    echo "     current 'git describe' version: $${git_ver}"; \
+	    echo "     current PACKAGE_VERSION:        $(PACKAGE_VERSION)"; \
+	    echo "Update PACKAGE_VERSION by running $(top_srcdir)/autogen.sh."; \
+	    rm -rf "$(top_srcdir)/autom4te.cache"; \
+	    exit 1; \
 	fi
 
 dist-stamps:

--- a/build-aux/calculate
+++ b/build-aux/calculate
@@ -7,12 +7,14 @@
 # ----------------------------------------------------------------------
 
 # Usage:
-#   calculate version|commit [path to stamp file]
+#   calculate version|commit [top_srcdir] [path to stamp file]
 #
 # Calculates the current version number.  When run from a distribution tarball,
 # we get the version number from the .version-stamp file (that our `make dist`
 # target ensures that it creates).  When run from a local git repository, we get
 # the version number via `git describe`.
+
+set -e
 
 WHAT="$1"
 case "$WHAT" in
@@ -21,8 +23,11 @@ case "$WHAT" in
   *) echo "Unknown option $WHAT" >&2; exit 1;;
 esac
 
+top_srcdir="${2-.}"
+export GIT_DIR="${top_srcdir}/.git"
+
 # First try the stamp file
-STAMP_FILE="$2"
+STAMP_FILE="$3"
 if [ -f "$STAMP_FILE" ]; then
   version=$(cat "$STAMP_FILE")
   if [ -z "$version" ]; then

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 # ------------------------------------------------------------------------------
 
 AC_INIT([libcork],
-        m4_esyscmd([build-aux/calculate version .version-stamp]),
+        m4_esyscmd([build-aux/calculate version . .version-stamp]),
         [info@libcork.io])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIR([m4])
@@ -28,7 +28,7 @@ BASE_VERSION=`AS_ECHO([$VERSION]) | sed -e 's/\+.*//'`
 AC_SUBST(VERSION_MAJOR, [`AS_ECHO([$BASE_VERSION]) | $AWK -F. '{print $1}'`])
 AC_SUBST(VERSION_MINOR, [`AS_ECHO([$BASE_VERSION]) | $AWK -F. '{print $2}'`])
 AC_SUBST(VERSION_PATCH, [`AS_ECHO([$BASE_VERSION]) | $AWK -F. '{print $3}'`])
-AC_SUBST(GIT_SHA1, m4_esyscmd([build-aux/calculate commit .commit-stamp]))
+AC_SUBST(GIT_SHA1, m4_esyscmd([build-aux/calculate commit . .commit-stamp]))
 AC_CONFIG_FILES([include/libcork/config/version.h])
 AC_PROG_CC
 AC_PROG_CC_C99

--- a/scripts/test
+++ b/scripts/test
@@ -31,8 +31,8 @@ fi
 build_autotools () {
   BUILDDIR=$(mktemp -d "$TMPDIR"/build-autotools-XXXXXX)
   echo "Using autotools to build in $BUILDDIR"
-  echo "$ autoreconf"
-  autoreconf -i
+  echo "$ autogen.sh"
+  "$SRCDIR"/autogen.sh
   cd "$BUILDDIR"
   echo "$ configure"
   CFLAGS="-g -O3 $ARCH_FLAGS" "$SRCDIR"/configure
@@ -62,7 +62,7 @@ build_cmake () {
 build_cmake_from_dist () {
   DISTDIR=$(mktemp -d "$TMPDIR"/build-dist-XXXXXX)
   echo "Using autotools to create dist tarball in $DISTDIR"
-  autoreconf -i
+  "$SRCDIR"/autogen.sh
   cd "$DISTDIR"
   echo "$ configure"
   CFLAGS="-g -O3 $ARCH_FLAGS" "$SRCDIR"/configure


### PR DESCRIPTION
We just added a new autogen.sh script, which we should use, instead of calling autoreconf directly.