### PR TITLE
Fix compilation errors with the recent gcc

### DIFF
--- a/tests/helpers.h
+++ b/tests/helpers.h
@@ -65,7 +65,7 @@ setup_allocator(void)
     do { \
         call; \
         if (cork_error_occurred()) { \
-            fail("%s", cork_error_message()); \
+            ck_abort_msg(cork_error_message()); \
         } \
     } while (0)
 
@@ -73,7 +73,7 @@ setup_allocator(void)
     do { \
         call; \
         if (!cork_error_occurred()) { \
-            fail(__VA_ARGS__); \
+            ck_abort_msg(__VA_ARGS__); \
         } else { \
             print_expected_failure(); \
         } \
@@ -81,15 +81,15 @@ setup_allocator(void)
     } while (0)
 
 #define fail_unless_equal(what, format, expected, actual) \
-    (fail_unless((expected) == (actual), \
+    (ck_assert_msg((expected) == (actual), \
                  "%s not equal (expected " format \
                  ", got " format ")", \
                  (what), (expected), (actual)))
 
 #define fail_unless_streq(what, expected, actual) \
-    (fail_unless(strcmp((expected), (actual)) == 0, \
+    (ck_assert_msg(strcmp((expected), (actual)) == 0, \
                  "%s not equal (expected \"%s\", got \"%s\")", \
                  (char *) (what), (char *) (expected), (char *) (actual)))
 
-
+#define ck_assert_false_msg(expr, ...) ck_assert_msg(!(expr), ## __VA_ARGS__)
 #endif /* TESTS_HELPERS_H */

--- a/tests/test-array.c
+++ b/tests/test-array.c
@@ -25,9 +25,9 @@
  */
 
 #define verify_size(array, expected_size)                                      \
-    fail_unless(cork_array_size((array)) == expected_size,                     \
+    ck_assert_msg(cork_array_size((array)) == expected_size,                     \
                 "Unexpected size of array: got %zu, expected %zu",             \
-                cork_array_size((array)), expected_size);
+                (size_t)cork_array_size((array)), (size_t)expected_size);
 
 #define add_element(element, expected_new_size)                                \
     fail_if_error(cork_array_append(&array, element));                         \
@@ -48,7 +48,7 @@
         for (i = 0; i < cork_array_size(array); i++) { \
             sum += cork_array_at(array, i); \
         } \
-        fail_unless(sum == expected, \
+        ck_assert_msg(sum == expected, \
                     "Unexpected sum, got %ld, expected %ld", \
                     (long) sum, (long) expected); \
     } while (0)
@@ -62,7 +62,7 @@
         cork_array(int_type) copy;                                             \
         cork_array_init(&array);                                               \
                                                                                \
-        fail_unless(cork_array_size(&array) == 0,                              \
+        ck_assert_msg(cork_array_size(&array) == 0,                              \
                     "Unexpected size of array: got %zu, expected 0",           \
                     cork_array_size(&array));                                  \
                                                                                \

--- a/tests/test-bitset.c
+++ b/tests/test-bitset.c
@@ -32,24 +32,24 @@ test_bitset_of_size(size_t bit_count)
 
     for (i = 0; i < bit_count; i++) {
         cork_bitset_set(set1, i, true);
-        fail_unless(cork_bitset_get(set1, i), "Unexpected value for bit %zu", i);
+        ck_assert_msg(cork_bitset_get(set1, i), "Unexpected value for bit %zu", i);
     }
 
     for (i = 0; i < bit_count; i++) {
         cork_bitset_set(set1, i, false);
-        fail_if(cork_bitset_get(set1, i), "Unexpected value for bit %zu", i);
+        ck_assert_false_msg(cork_bitset_get(set1, i), "Unexpected value for bit %zu", i);
     }
     cork_bitset_free(set1);
 
     cork_bitset_init(&set2, bit_count);
     for (i = 0; i < bit_count; i++) {
         cork_bitset_set(&set2, i, true);
-        fail_unless(cork_bitset_get(&set2, i), "Unexpected value for bit %zu", i);
+        ck_assert_msg(cork_bitset_get(&set2, i), "Unexpected value for bit %zu", i);
     }
 
     for (i = 0; i < bit_count; i++) {
         cork_bitset_set(&set2, i, false);
-        fail_if(cork_bitset_get(&set2, i), "Unexpected value for bit %zu", i);
+        ck_assert_false_msg(cork_bitset_get(&set2, i), "Unexpected value for bit %zu", i);
     }
     cork_bitset_done(&set2);
 }

--- a/tests/test-buffer.c
+++ b/tests/test-buffer.c
@@ -28,18 +28,18 @@
 static void
 check_buffers(const struct cork_buffer *buf1, const struct cork_buffer *buf2)
 {
-    fail_unless(cork_buffer_equal(buf1, buf2),
+    ck_assert_msg(cork_buffer_equal(buf1, buf2),
                 "Buffers should be equal: got %zu:%s, expected %zu:%s",
-                buf1->size, buf1->buf, buf2->size, buf2->buf);
+                buf1->size, (char*)buf1->buf, buf2->size, (char*)buf2->buf);
 }
 
 static void
 check_buffer(const struct cork_buffer *buf, const char *expected)
 {
     size_t  expected_len = strlen(expected);
-    fail_unless(buf->size == expected_len,
+    ck_assert_msg(buf->size == expected_len,
                 "Unexpected buffer content: got %zu:%s, expected %zu:%s",
-                buf->size, buf->buf, expected_len, expected);
+                buf->size, (char*)buf->buf, expected_len, expected);
 }
 
 START_TEST(test_buffer)
@@ -56,11 +56,11 @@ START_TEST(test_buffer)
     cork_buffer_init(&buffer1);
     fail_if_error(cork_buffer_set(&buffer1, SRC, SRC_LEN));
 
-    fail_unless(cork_buffer_char(&buffer1, 0) == 'H',
+    ck_assert_msg(cork_buffer_char(&buffer1, 0) == 'H',
                 "Unexpected character at position 0: got %c, expected %c",
                 (int) cork_buffer_char(&buffer1, 0), (int) 'H');
 
-    fail_unless(cork_buffer_byte(&buffer1, 1) == (uint8_t) 'e',
+    ck_assert_msg(cork_buffer_byte(&buffer1, 1) == (uint8_t) 'e',
                 "Unexpected character at position 1: got %c, expected %c",
                 (int) cork_buffer_byte(&buffer1, 1), (int) 'e');
 
@@ -127,9 +127,9 @@ START_TEST(test_buffer_append)
                   (buffer3, "%s%s%s", SRC2, SRC3, SRC4));
     check_buffers(&buffer1, buffer3);
 
-    fail_unless(cork_buffer_equal(&buffer1, buffer3),
+    ck_assert_msg(cork_buffer_equal(&buffer1, buffer3),
                 "Buffers should be equal: got %zu:%s, expected %zu:%s",
-                buffer1.size, buffer1.buf, buffer3->size, buffer3->buf);
+                buffer1.size, (char*)buffer1.buf, buffer3->size, (char*)buffer3->buf);
 
     cork_buffer_done(&buffer1);
     cork_buffer_done(&buffer2);
@@ -176,7 +176,7 @@ START_TEST(test_buffer_slicing)
     fail_if_error(cork_slice_slice_offset_fast(&slice2, 2));
     fail_if_error(cork_slice_slice_fast(&slice2, 0, 2));
     fail_if_error(cork_slice_slice(&slice1, 2, 2));
-    fail_unless(cork_slice_equal(&slice1, &slice2), "Slices should be equal");
+    ck_assert_msg(cork_slice_equal(&slice1, &slice2), "Slices should be equal");
     cork_slice_finish(&slice2);
 
     cork_slice_finish(&slice1);

--- a/tests/test-core.c
+++ b/tests/test-core.c
@@ -38,10 +38,10 @@ START_TEST(test_bool)
     bool  value;
 
     value = true;
-    fail_unless(value, "Unexpected true value");
+    ck_assert_msg(value, "Unexpected true value");
 
     value = false;
-    fail_if(value, "Unexpected false value");
+    ck_assert_false_msg(value, "Unexpected false value");
 }
 END_TEST
 
@@ -55,7 +55,7 @@ START_TEST(test_int_types)
 #define TEST_INT_TYPE(type) \
     { \
         type  i = 0; \
-        fail_unless(i == 0, "Unexpected value for " #type); \
+        ck_assert_msg(i == 0, "Unexpected value for " #type); \
     }
 
     TEST_INT_TYPE(int8_t);
@@ -85,7 +85,7 @@ START_TEST(test_int_sizeof)
 
 #define TEST_SIZEOF(TYPE, type) \
     { \
-        fail_unless(CORK_SIZEOF_##TYPE == sizeof(type), \
+        ck_assert_msg(CORK_SIZEOF_##TYPE == sizeof(type), \
                     "Incorrect size for " #type ": got %zu, expected %zu", \
                     (size_t) CORK_SIZEOF_##TYPE, \
                     (size_t) sizeof(type)); \
@@ -117,20 +117,20 @@ test_strndup(const char *string, size_t size)
 
     copy = cork_strndup(string, size);
     if (memcmp(string, copy, size) != 0) {
-        fail("cork_strndup failed");
+        ck_abort_msg("cork_strndup failed");
     }
     if (cork_strlen(copy) != size) {
-        fail("cork_strlen failed");
+        ck_abort_msg("cork_strlen failed");
     }
     cork_strfree(copy);
 
     copy = cork_xstrndup(string, size);
-    fail_if(copy == NULL, "cork_xstrndup couldn't allocate copy");
+    ck_assert_false_msg(copy == NULL, "cork_xstrndup couldn't allocate copy");
     if (memcmp(string, copy, size) != 0) {
-        fail("cork_xstrndup failed");
+        ck_abort_msg("cork_xstrndup failed");
     }
     if (cork_strlen(copy) != size) {
-        fail("cork_strlen failed");
+        ck_abort_msg("cork_strlen failed");
     }
     cork_strfree(copy);
 }
@@ -162,21 +162,21 @@ START_TEST(test_endianness)
             { { __VA_ARGS__ } }; \
         \
         type  from_big = CORK_##TYPE##_BIG_TO_HOST(u.val); \
-        fail_unless(type##_eq(from_big, expected), \
+        ck_assert_msg(type##_eq(from_big, expected), \
                     "Unexpected big-to-host " #type " value"); \
         \
         type  from_big_in_place = u.val; \
         CORK_##TYPE##_BIG_TO_HOST_IN_PLACE(from_big_in_place); \
-        fail_unless(type##_eq(from_big_in_place, expected), \
+        ck_assert_msg(type##_eq(from_big_in_place, expected), \
                     "Unexpected in-place big-to-host " #type " value"); \
         \
         type  to_big = CORK_##TYPE##_HOST_TO_BIG(expected); \
-        fail_unless(type##_eq(to_big, u.val), \
+        ck_assert_msg(type##_eq(to_big, u.val), \
                     "Unexpected host-to-big " #type " value"); \
         \
         type  to_big_in_place = expected; \
         CORK_##TYPE##_HOST_TO_BIG_IN_PLACE(to_big_in_place); \
-        fail_unless(type##_eq(to_big_in_place, u.val), \
+        ck_assert_msg(type##_eq(to_big_in_place, u.val), \
                     "Unexpected in-place host-to-big " #type " value"); \
         \
         int  i; \
@@ -187,21 +187,21 @@ START_TEST(test_endianness)
         } \
         \
         type  from_little = CORK_##TYPE##_LITTLE_TO_HOST(u.val); \
-        fail_unless(type##_eq(from_little, expected), \
+        ck_assert_msg(type##_eq(from_little, expected), \
                     "Unexpected little-to-host " #type " value"); \
         \
         type  from_little_in_place = u.val; \
         CORK_##TYPE##_LITTLE_TO_HOST_IN_PLACE(from_little_in_place); \
-        fail_unless(type##_eq(from_little_in_place, expected), \
+        ck_assert_msg(type##_eq(from_little_in_place, expected), \
                     "Unexpected in-place little-to-host " #type " value"); \
         \
         type  to_little = CORK_##TYPE##_HOST_TO_LITTLE(expected); \
-        fail_unless(type##_eq(to_little, u.val), \
+        ck_assert_msg(type##_eq(to_little, u.val), \
                     "Unexpected host-to-little " #type " value"); \
         \
         type  to_little_in_place = expected; \
         CORK_##TYPE##_HOST_TO_LITTLE_IN_PLACE(to_little_in_place); \
-        fail_unless(type##_eq(to_little_in_place, u.val), \
+        ck_assert_msg(type##_eq(to_little_in_place, u.val), \
                     "Unexpected in-place host-to-little " #type " value"); \
     }
 
@@ -247,7 +247,7 @@ START_TEST(test_system_error)
     errno = ENOMEM;
     cork_error_clear();
     cork_system_error_set();
-    fail_unless(cork_error_code() == ENOMEM,
+    ck_assert_msg(cork_error_code() == ENOMEM,
                 "Expected a system error");
     printf("Got error: %s\n", cork_error_message());
     cork_error_clear();
@@ -260,7 +260,7 @@ END_TEST
  */
 
 #define test_hash_func(func, expected, ...) \
-    fail_unless(func(0, __VA_ARGS__) == expected, \
+    ck_assert_msg(func(0, __VA_ARGS__) == expected, \
                 "Unexpected hash value 0x%08" PRIx32 \
                 " (expected 0x%08" PRIx32 ")", \
                 func(0, __VA_ARGS__), expected);
@@ -303,7 +303,7 @@ END_TEST
         cork_big_hash  seed = CORK_BIG_HASH_INIT(); \
         cork_big_hash  expected = {cork_u128_from_64(e1, e2)}; \
         cork_big_hash  actual = cork_big_hash_buffer(seed, buf, len); \
-        fail_unless(cork_big_hash_equal(actual, expected), \
+        ck_assert_msg(cork_big_hash_equal(actual, expected), \
                     "\nUnexpected hash value 0x%016" PRIx64 ".%016" PRIx64 \
                     "\n            (expected 0x%016" PRIx64 ".%016" PRIx64 ")", \
                     cork_u128_be64(actual.u128, 0), \
@@ -482,14 +482,14 @@ START_TEST(test_ipv4_address)
         fail_if_error(cork_ipv4_init(&addr, str)); \
         char  actual[CORK_IPV4_STRING_LENGTH]; \
         cork_ipv4_to_raw_string(&addr, actual); \
-        fail_unless(strcmp(actual, normalized) == 0, \
+        ck_assert_msg(strcmp(actual, normalized) == 0, \
                     "Unexpected string representation: " \
                     "got \"%s\", expected \"%s\"", \
                     actual, normalized); \
         \
         struct cork_ipv4  addr2; \
         cork_ipv4_init(&addr2, normalized); \
-        fail_unless(cork_ipv4_equal(&addr, &addr2), \
+        ck_assert_msg(cork_ipv4_equal(&addr, &addr2), \
                     "IPv4 instances should be equal"); \
     }
 
@@ -515,14 +515,14 @@ START_TEST(test_ipv4_address)
 
     fprintf(stderr, "Testing network prefixes\n");
     cork_ipv4_init(&addr4, "1.2.3.4");
-    fail_unless(cork_ipv4_is_valid_network(&addr4, ipv4_cidr_good),
+    ck_assert_msg(cork_ipv4_is_valid_network(&addr4, ipv4_cidr_good),
                 "Bad CIDR block for 1.2.3.4 and %u",
                 ipv4_cidr_good);
-    fail_if(cork_ipv4_is_valid_network(&addr4, ipv4_cidr_bad_value),
-            "IPv4 CIDR check should fail for %u",
+    ck_assert_false_msg(cork_ipv4_is_valid_network(&addr4, ipv4_cidr_bad_value),
+            "IPv4 CIDR check should ck_abort_msg for %u",
             ipv4_cidr_bad_value);
-    fail_if(cork_ipv4_is_valid_network(&addr4, ipv4_cidr_bad_range),
-            "IPv4 CIDR check should fail for %u",
+    ck_assert_false_msg(cork_ipv4_is_valid_network(&addr4, ipv4_cidr_bad_range),
+            "IPv4 CIDR check should ck_abort_msg for %u",
             ipv4_cidr_bad_range);
 }
 END_TEST
@@ -538,14 +538,14 @@ START_TEST(test_ipv6_address)
         fail_if_error(cork_ipv6_init(&addr, str)); \
         char  actual[CORK_IPV6_STRING_LENGTH]; \
         cork_ipv6_to_raw_string(&addr, actual); \
-        fail_unless(strcmp(actual, normalized) == 0, \
+        ck_assert_msg(strcmp(actual, normalized) == 0, \
                     "Unexpected string representation: " \
                     "got \"%s\", expected \"%s\"", \
                     actual, normalized); \
         \
         struct cork_ipv6  addr2; \
         cork_ipv6_init(&addr2, normalized); \
-        fail_unless(cork_ipv6_equal(&addr, &addr2), \
+        ck_assert_msg(cork_ipv6_equal(&addr, &addr2), \
                     "IPv6 instances should be equal"); \
     }
 
@@ -571,14 +571,14 @@ START_TEST(test_ipv6_address)
 
     fprintf(stderr, "Testing network prefixes\n");
     cork_ipv6_init(&addr6, "fe80::200:f8ff:fe21:6000");
-    fail_unless(cork_ipv6_is_valid_network(&addr6, ipv6_cidr_good),
+    ck_assert_msg(cork_ipv6_is_valid_network(&addr6, ipv6_cidr_good),
                 "Bad CIDR block %u",
                 ipv6_cidr_good);
-    fail_if(cork_ipv6_is_valid_network(&addr6, ipv6_cidr_bad_value),
-            "IPv6 CIDR check should fail for %u",
+    ck_assert_false_msg(cork_ipv6_is_valid_network(&addr6, ipv6_cidr_bad_value),
+            "IPv6 CIDR check should ck_abort_msg for %u",
             ipv6_cidr_bad_value);
-    fail_if(cork_ipv6_is_valid_network(&addr6, ipv6_cidr_bad_range),
-            "IPv6 CIDR check should fail for %u",
+    ck_assert_false_msg(cork_ipv6_is_valid_network(&addr6, ipv6_cidr_bad_range),
+            "IPv6 CIDR check should ck_abort_msg for %u",
             ipv6_cidr_bad_range);
 }
 END_TEST
@@ -595,14 +595,14 @@ START_TEST(test_ip_address)
         fail_if_error(cork_ip_init(&addr, str)); \
         char  actual[CORK_IP_STRING_LENGTH]; \
         cork_ip_to_raw_string(&addr, actual); \
-        fail_unless(strcmp(actual, normalized) == 0, \
+        ck_assert_msg(strcmp(actual, normalized) == 0, \
                     "Unexpected string representation: " \
                     "got \"%s\", expected \"%s\"", \
                     actual, normalized); \
         \
         struct cork_ip  addr2; \
         cork_ip_init(&addr2, normalized); \
-        fail_unless(cork_ip_equal(&addr, &addr2), \
+        ck_assert_msg(cork_ip_equal(&addr, &addr2), \
                     "IP instances should be equal"); \
     }
 
@@ -627,18 +627,18 @@ START_TEST(test_ip_address)
     fprintf(stderr, "Testing IP address versions\n");
     cork_ip_init(&addr, "192.168.1.1");
     cork_ipv4_init(&addr4, "192.168.1.1");
-    fail_unless(addr.version == 4,
+    ck_assert_msg(addr.version == 4,
                 "Unexpected IP address version (expected 4, got %u)",
                 addr.version);
-    fail_unless(cork_ipv4_equal(&addr.ip.v4, &addr4),
+    ck_assert_msg(cork_ipv4_equal(&addr.ip.v4, &addr4),
                 "IP addresses should be equal");
 
     cork_ip_init(&addr, "fe80::1");
     cork_ipv6_init(&addr6, "fe80::1");
-    fail_unless(addr.version == 6,
+    ck_assert_msg(addr.version == 6,
                 "Unexpected IP address version (expected 6, got %u)",
                 addr.version);
-    fail_unless(cork_ipv6_equal(&addr.ip.v6, &addr6),
+    ck_assert_msg(cork_ipv6_equal(&addr.ip.v6, &addr6),
                 "IP addresses should be equal");
 }
 END_TEST
@@ -652,7 +652,7 @@ static void
 test_timestamp_bad_format(cork_timestamp ts, const char *format)
 {
     struct cork_buffer  buf = CORK_BUFFER_INIT();
-    fail_unless_error(cork_timestamp_format_utc(ts, format, &buf));
+    fail_unless_error(cork_timestamp_format_utc(ts, format, &buf), "Error in cork_timestamp_format_utc");
     cork_buffer_done(&buf);
 }
 
@@ -662,7 +662,7 @@ test_timestamp_utc_format(cork_timestamp ts, const char *format,
 {
     struct cork_buffer  buf = CORK_BUFFER_INIT();
     fail_if_error(cork_timestamp_format_utc(ts, format, &buf));
-    fail_unless(strcmp(buf.buf, expected) == 0,
+    ck_assert_msg(strcmp(buf.buf, expected) == 0,
                 "Unexpected formatted UTC time "
                 "(got \"%s\", expected \"%s\")",
                 (char *) buf.buf, expected);
@@ -675,7 +675,7 @@ test_timestamp_local_format(cork_timestamp ts, const char *format,
 {
     struct cork_buffer  buf = CORK_BUFFER_INIT();
     fail_if_error(cork_timestamp_format_local(ts, format, &buf));
-    fail_unless(strcmp(buf.buf, expected) == 0,
+    ck_assert_msg(strcmp(buf.buf, expected) == 0,
                 "Unexpected formatted local time "
                 "(got \"%s\", expected \"%s\")",
                 (char *) buf.buf, expected);
@@ -706,7 +706,7 @@ START_TEST(test_timestamp)
     DESCRIBE_TEST;
 
 #define test(unit, expected) \
-    fail_unless(cork_timestamp_##unit(ts) == expected, \
+    ck_assert_msg(cork_timestamp_##unit(ts) == expected, \
                 "Unexpected " #unit " portion of timestamp " \
                 "(got %lu, expected %lu)", \
                 (unsigned long) cork_timestamp_##unit(ts), \
@@ -826,15 +826,15 @@ START_TEST(test_uid)
 
     id1 = test_id_01;
     id2 = test_id_02;
-    fail_if(cork_uid_equal(id1, id2), "Unique IDs aren't unique");
+    ck_assert_false_msg(cork_uid_equal(id1, id2), "Unique IDs aren't unique");
 
     id1 = test_id_01;
     id2 = test_id_01;
-    fail_unless(cork_uid_equal(id1, id2), "Unique ID isn't equal to itself");
+    ck_assert_msg(cork_uid_equal(id1, id2), "Unique ID isn't equal to itself");
 
     id1 = test_id_01;
     id2 = CORK_UID_NONE;
-    fail_if(cork_uid_equal(id1, id2), "NULL unique ID isn't unique");
+    ck_assert_false_msg(cork_uid_equal(id1, id2), "NULL unique ID isn't unique");
 }
 END_TEST
 

--- a/tests/test-dllist.c
+++ b/tests/test-dllist.c
@@ -72,37 +72,37 @@ START_TEST(test_dllist)
     int64_t  sum;
 
     cork_dllist_init(&list);
-    fail_unless(cork_dllist_size(&list) == 0,
+    ck_assert_msg(cork_dllist_size(&list) == 0,
                 "Unexpected size of list: got %zu, expected 0",
                 cork_dllist_size(&list));
-    fail_unless(cork_dllist_is_empty(&list),
+    ck_assert_msg(cork_dllist_is_empty(&list),
                 "Expected empty list");
     check_int64_list(&list, "");
 
     item1.value = 1;
     cork_dllist_add(&list, &item1.element);
-    fail_unless(cork_dllist_size(&list) == 1,
+    ck_assert_msg(cork_dllist_size(&list) == 1,
                 "Unexpected size of list: got %zu, expected 1",
                 cork_dllist_size(&list));
     check_int64_list(&list, "1");
 
     item2.value = 2;
     cork_dllist_add(&list, &item2.element);
-    fail_unless(cork_dllist_size(&list) == 2,
+    ck_assert_msg(cork_dllist_size(&list) == 2,
                 "Unexpected size of list: got %zu, expected 2",
                 cork_dllist_size(&list));
     check_int64_list(&list, "1,2");
 
     item3.value = 3;
     cork_dllist_add(&list, &item3.element);
-    fail_unless(cork_dllist_size(&list) == 3,
+    ck_assert_msg(cork_dllist_size(&list) == 3,
                 "Unexpected size of list: got %zu, expected 3",
                 cork_dllist_size(&list));
     check_int64_list(&list, "1,2,3");
 
     sum = 0;
-    fail_if(cork_dllist_visit(&list, &sum, int64_sum));
-    fail_unless(sum == 6,
+    ck_assert(!cork_dllist_visit(&list, &sum, int64_sum));
+    ck_assert_msg(sum == 6,
                 "Unexpected sum, got %ld, expected 6",
                 (long) sum);
 
@@ -110,12 +110,12 @@ START_TEST(test_dllist)
     cork_dllist_foreach(&list, curr, next, struct int64_item, item, element) {
         sum += item->value;
     }
-    fail_unless(sum == 6,
+    ck_assert_msg(sum == 6,
                 "Unexpected sum, got %ld, expected 6",
                 (long) sum);
 
     cork_dllist_remove(&item2.element);
-    fail_unless(cork_dllist_size(&list) == 2,
+    ck_assert_msg(cork_dllist_size(&list) == 2,
                 "Unexpected size of list: got %zu, expected 2",
                 cork_dllist_size(&list));
 }

--- a/tests/test-files.c
+++ b/tests/test-files.c
@@ -31,7 +31,7 @@ static const char  *program_path;
 void
 verify_path_content(struct cork_path *path, const char *expected)
 {
-    fail_if(cork_path_get(path) == NULL, "Path should not have NULL content");
+    ck_assert_false_msg(cork_path_get(path) == NULL, "Path should not have NULL content");
     fail_unless_streq("Paths", expected, cork_path_get(path));
 }
 
@@ -357,7 +357,7 @@ test_file_exists(const char *filename, bool expected)
     cork_path_append(path, filename);
     file = cork_file_new_from_path(path);
     fail_if_error(cork_file_exists(file, &actual));
-    fail_unless(actual == expected, "File %s should%s exist",
+    ck_assert_msg(actual == expected, "File %s should%s exist",
                 cork_path_get(path), expected? "": " not");
     cork_file_free(file);
 }

--- a/tests/test-hash-table.c
+++ b/tests/test-hash-table.c
@@ -68,7 +68,7 @@ test_map_sum(struct cork_hash_table *table, uint64_t expected)
 {
     uint64_t  sum = 0;
     cork_hash_table_map(table, &sum, uint64_sum);
-    fail_unless(sum == expected,
+    ck_assert_msg(sum == expected,
                 "Unexpected map sum, got %" PRIu64
                 ", expected %" PRIu64,
                 sum, expected);
@@ -85,7 +85,7 @@ test_iterator_sum(struct cork_hash_table *table, uint64_t expected)
         uint64_t  *value_ptr = entry->value;
         sum += *value_ptr;
     }
-    fail_unless(sum == expected,
+    ck_assert_msg(sum == expected,
                 "Unexpected iterator sum, got %" PRIu64
                 ", expected %" PRIu64 "",
                 sum, expected);
@@ -150,11 +150,11 @@ START_TEST(test_uint64_hash_table)
     cork_hash_table_set_equals(table, uint64__equals);
     cork_hash_table_set_free_key(table, uint64__free);
     cork_hash_table_set_free_value(table, uint64__free);
-    fail_unless(cork_hash_table_size(table) == 0,
+    ck_assert_msg(cork_hash_table_size(table) == 0,
                 "Hash table should start empty");
 
     key = 0;
-    fail_unless(cork_hash_table_get(table, &key) == NULL,
+    ck_assert_msg(cork_hash_table_get(table, &key) == NULL,
                 "Shouldn't get value pointer from empty hash table");
 
     test_map_sum(table, 0);
@@ -169,32 +169,32 @@ START_TEST(test_uint64_hash_table)
     fail_if_error(cork_hash_table_put
                   (table, key_ptr, value_ptr,
                    &is_new, &v_key, &v_value));
-    fail_unless(is_new, "Couldn't append {0=>32} to hash table");
+    ck_assert_msg(is_new, "Couldn't append {0=>32} to hash table");
     old_key = v_key;
     old_value = v_value;
 
-    fail_unless(old_key == NULL,
+    ck_assert_msg(old_key == NULL,
                 "Unexpected previous key");
-    fail_unless(old_value == NULL,
+    ck_assert_msg(old_value == NULL,
                 "Unexpected previous value");
 
-    fail_unless(cork_hash_table_size(table) == 1,
+    ck_assert_msg(cork_hash_table_size(table) == 1,
                 "Unexpected size after adding {0->32}");
 
     fail_if_error(entry = cork_hash_table_get_or_create
                   (table, &key, &is_new));
-    fail_if(is_new, "Shouldn't create new {0=>X} entry");
+    ck_assert_false_msg(is_new, "Shouldn't create new {0=>X} entry");
     value_ptr = entry->value;
-    fail_unless(*value_ptr == 32,
+    ck_assert_msg(*value_ptr == 32,
                 "Unexpected value for {0=>X} entry");
 
-    fail_unless(cork_hash_table_size(table) == 1,
+    ck_assert_msg(cork_hash_table_size(table) == 1,
                 "Unexpected size after retrieving {0->32}");
 
     key = 1;
     fail_if_error(entry = cork_hash_table_get_or_create
                   (table, &key, &is_new));
-    fail_unless(is_new, "Should create new {1=>X} entry");
+    ck_assert_msg(is_new, "Should create new {1=>X} entry");
     key_ptr = cork_new(uint64_t);
     *key_ptr = key;
     entry->key = key_ptr;
@@ -202,7 +202,7 @@ START_TEST(test_uint64_hash_table)
     *value_ptr = 2;
     entry->value = value_ptr;
 
-    fail_unless(cork_hash_table_size(table) == 2,
+    ck_assert_msg(cork_hash_table_size(table) == 2,
                 "Unexpected size after adding {1=>2}");
 
     test_map_sum(table, 34);
@@ -211,22 +211,22 @@ START_TEST(test_uint64_hash_table)
     test_iterator_to_string(table, "[0:32, 1:2]");
 
     key = 0;
-    fail_unless(cork_hash_table_delete(table, &key, NULL, NULL),
+    ck_assert_msg(cork_hash_table_delete(table, &key, NULL, NULL),
                 "Couldn't delete {0=>32}");
 
-    fail_unless(cork_hash_table_size(table) == 1,
+    ck_assert_msg(cork_hash_table_size(table) == 1,
                 "Unexpected size after deleting entry");
 
     test_map_to_string(table, "[1:2]");
     test_iterator_to_string(table, "[1:2]");
 
     key = 3;
-    fail_if(cork_hash_table_delete(table, &key, NULL, NULL),
+    ck_assert_false_msg(cork_hash_table_delete(table, &key, NULL, NULL),
             "Shouldn't be able to delete nonexistent {3=>X}");
 
     cork_hash_table_delete_entry(table, entry);
 
-    fail_unless(cork_hash_table_size(table) == 0,
+    ck_assert_msg(cork_hash_table_size(table) == 0,
                 "Unexpected size after deleting last entry");
 
     /*
@@ -241,7 +241,7 @@ START_TEST(test_uint64_hash_table)
     fail_if_error(cork_hash_table_put
                   (table, key_ptr, value_ptr,
                    &is_new, &v_key, &v_value));
-    fail_unless(is_new, "Couldn't append {0=>32} to hash table");
+    ck_assert_msg(is_new, "Couldn't append {0=>32} to hash table");
     old_key = v_key;
     old_value = v_value;
 
@@ -252,12 +252,12 @@ START_TEST(test_uint64_hash_table)
     fail_if_error(cork_hash_table_put
                   (table, key_ptr, value_ptr,
                    &is_new, &v_key, &v_value));
-    fail_unless(is_new, "Couldn't append {1=>2} to hash table");
+    ck_assert_msg(is_new, "Couldn't append {1=>2} to hash table");
     old_key = v_key;
     old_value = v_value;
 
     cork_hash_table_clear(table);
-    fail_unless(cork_hash_table_size(table) == 0,
+    ck_assert_msg(cork_hash_table_size(table) == 0,
                 "Unexpected size after deleting entries using map");
 
     /* And we're done, so let's free everything. */
@@ -280,18 +280,18 @@ START_TEST(test_string_hash_table)
 
     fail_if_error(cork_hash_table_put
                   (table, "key1", (void *) (uintptr_t) 1, NULL, NULL, NULL));
-    fail_unless(cork_hash_table_size(table) == 1,
+    ck_assert_msg(cork_hash_table_size(table) == 1,
                 "Unexpected size after adding {key1->1}");
 
     strncpy(key, "key1", sizeof(key));
-    fail_if((value = cork_hash_table_get(table, key)) == NULL,
+    ck_assert_false_msg((value = cork_hash_table_get(table, key)) == NULL,
             "No entry for key1");
 
-    fail_unless(value == (void *) (uintptr_t) 1,
+    ck_assert_msg(value == (void *) (uintptr_t) 1,
                 "Unexpected value for key1");
 
     strncpy(key, "key2", sizeof(key));
-    fail_unless((value = cork_hash_table_get(table, key)) == NULL,
+    ck_assert_msg((value = cork_hash_table_get(table, key)) == NULL,
                 "Unexpected entry for key2");
 
     cork_hash_table_free(table);
@@ -314,16 +314,16 @@ START_TEST(test_pointer_hash_table)
 
     fail_if_error(cork_hash_table_put
                   (table, &key1, (void *) (uintptr_t) 1, NULL, NULL, NULL));
-    fail_unless(cork_hash_table_size(table) == 1,
+    ck_assert_msg(cork_hash_table_size(table) == 1,
                 "Unexpected size after adding {key1->1}");
 
-    fail_if((value = cork_hash_table_get(table, &key1)) == NULL,
+    ck_assert_false_msg((value = cork_hash_table_get(table, &key1)) == NULL,
             "No entry for key1");
 
-    fail_unless(value == (void *) (uintptr_t) 1,
+    ck_assert_msg(value == (void *) (uintptr_t) 1,
                 "Unexpected value for key1");
 
-    fail_unless((value = cork_hash_table_get(table, &key2)) == NULL,
+    ck_assert_msg((value = cork_hash_table_get(table, &key2)) == NULL,
                 "Unexpected entry for key2");
 
     cork_hash_table_free(table);

--- a/tests/test-managed-buffer.c
+++ b/tests/test-managed-buffer.c
@@ -81,7 +81,7 @@ START_TEST(test_managed_buffer_refcount)
     cork_managed_buffer_unref(pb2);
     cork_managed_buffer_unref(pb3);
 
-    fail_unless(flag,
+    ck_assert_msg(flag,
                 "Managed buffer free function never called.");
 }
 END_TEST
@@ -108,7 +108,7 @@ START_TEST(test_managed_buffer_bad_refcount)
     /* cork_managed_buffer_unref(pb3);   OH NO! */
     (void) pb3;
 
-    fail_if(flag,
+    ck_assert_false_msg(flag,
             "Managed buffer free function was called unexpectedly.");
 
     /* free the buffer here to quiet valgrind */
@@ -176,7 +176,7 @@ START_TEST(test_slice_refcount)
     cork_slice_finish(&ps2);
     cork_slice_finish(&ps3);
 
-    fail_unless(flag,
+    ck_assert_msg(flag,
                 "Managed buffer free function never called.");
 }
 END_TEST
@@ -211,7 +211,7 @@ START_TEST(test_slice_bad_refcount)
     cork_slice_finish(&ps2);
     /* cork_slice_finish(&ps3);   OH NO! */
 
-    fail_if(flag,
+    ck_assert_false_msg(flag,
             "Managed buffer free function was called unexpectedly.");
 
     /* free the slice here to quiet valgrind */
@@ -244,7 +244,7 @@ START_TEST(test_slice_equals_01)
     fail_if_error(cork_managed_buffer_slice_offset(&ps1, pb, 0));
     fail_if_error(cork_managed_buffer_slice(&ps2, pb, 0, LEN));
 
-    fail_unless(cork_slice_equal(&ps1, &ps2),
+    ck_assert_msg(cork_slice_equal(&ps1, &ps2),
                 "Slices aren't equal");
 
     cork_managed_buffer_unref(pb);
@@ -278,9 +278,9 @@ START_TEST(test_slice_equals_02)
     fail_if_error(cork_slice_copy(&ps3, &ps2, 2, 3));
     fail_if_error(cork_slice_slice(&ps2, 2, 3));
 
-    fail_unless(cork_slice_equal(&ps1, &ps2),
+    ck_assert_msg(cork_slice_equal(&ps1, &ps2),
                 "Slices aren't equal");
-    fail_unless(cork_slice_equal(&ps1, &ps3),
+    ck_assert_msg(cork_slice_equal(&ps1, &ps3),
                 "Slices aren't equal");
 
     cork_managed_buffer_unref(pb);

--- a/tests/test-mempool.c
+++ b/tests/test-mempool.c
@@ -36,7 +36,7 @@ START_TEST(test_mempool_01)
     size_t  i;
     int64_t  *objects[OBJECT_COUNT];
     for (i = 0; i < OBJECT_COUNT; i++) {
-        fail_if((objects[i] = cork_mempool_new_object(mp)) == NULL,
+        ck_assert_false_msg((objects[i] = cork_mempool_new_object(mp)) == NULL,
                 "Cannot allocate object #%zu", i);
     }
 
@@ -45,7 +45,7 @@ START_TEST(test_mempool_01)
     }
 
     for (i = 0; i < OBJECT_COUNT; i++) {
-        fail_if((objects[i] = cork_mempool_new_object(mp)) == NULL,
+        ck_assert_false_msg((objects[i] = cork_mempool_new_object(mp)) == NULL,
                 "Cannot reallocate object #%zu", i);
     }
 
@@ -64,7 +64,7 @@ START_TEST(test_mempool_fail_01)
     mp = cork_mempool_new(int64_t);
 
     int64_t  *obj;
-    fail_if((obj = cork_mempool_new_object(mp)) == NULL,
+    ck_assert_false_msg((obj = cork_mempool_new_object(mp)) == NULL,
             "Cannot allocate object");
 
     /* This should raise an assertion since we never freed obj. */
@@ -105,25 +105,25 @@ START_TEST(test_mempool_reuse_01)
     cork_mempool_set_done_object(mp, int64_done);
 
     int64_t  *obj;
-    fail_if((obj = cork_mempool_new_object(mp)) == NULL,
+    ck_assert_false_msg((obj = cork_mempool_new_object(mp)) == NULL,
             "Cannot allocate object");
 
     /* The init_object function sets the value to 12 */
-    fail_unless(*obj == 12, "Unexpected value %" PRId64, *obj);
+    ck_assert_msg(*obj == 12, "Unexpected value %" PRId64, *obj);
 
     /* Set the value to something new, free the object, then reallocate.
      * Since we know memory pools are LIFO, we should get back the same
      * object, unchanged. */
     *obj = 42;
     cork_mempool_free_object(mp, obj);
-    fail_if((obj = cork_mempool_new_object(mp)) == NULL,
+    ck_assert_false_msg((obj = cork_mempool_new_object(mp)) == NULL,
             "Cannot allocate object");
-    fail_unless(*obj == 42, "Unexpected value %" PRId64, *obj);
+    ck_assert_msg(*obj == 42, "Unexpected value %" PRId64, *obj);
 
     cork_mempool_free_object(mp, obj);
     cork_mempool_free(mp);
 
-    fail_unless(done_call_count ==
+    ck_assert_msg(done_call_count ==
                 OBJECTS_PER_BLOCK(BLOCK_SIZE, sizeof(int64_t)),
                 "done_object called an unexpected number of times: %zu",
                 done_call_count);

--- a/tests/test-ring-buffer.c
+++ b/tests/test-ring-buffer.c
@@ -28,40 +28,40 @@ START_TEST(test_ring_buffer_1)
     struct cork_ring_buffer  buf;
     cork_ring_buffer_init(&buf, 4);
 
-    fail_unless(cork_ring_buffer_add(&buf, (void *) 1) == 0,
+    ck_assert_msg(cork_ring_buffer_add(&buf, (void *) 1) == 0,
                 "Cannot add to ring buffer");
-    fail_unless(cork_ring_buffer_add(&buf, (void *) 2) == 0,
+    ck_assert_msg(cork_ring_buffer_add(&buf, (void *) 2) == 0,
                 "Cannot add to ring buffer");
-    fail_unless(cork_ring_buffer_add(&buf, (void *) 3) == 0,
+    ck_assert_msg(cork_ring_buffer_add(&buf, (void *) 3) == 0,
                 "Cannot add to ring buffer");
-    fail_unless(cork_ring_buffer_add(&buf, (void *) 4) == 0,
+    ck_assert_msg(cork_ring_buffer_add(&buf, (void *) 4) == 0,
                 "Cannot add to ring buffer");
-    fail_if(cork_ring_buffer_add(&buf, (void *) 5) == 0,
+    ck_assert_false_msg(cork_ring_buffer_add(&buf, (void *) 5) == 0,
             "Shouldn't be able to add to ring buffer");
 
-    fail_unless(((intptr_t) cork_ring_buffer_peek(&buf)) == 1,
+    ck_assert_msg(((intptr_t) cork_ring_buffer_peek(&buf)) == 1,
                 "Unexpected head of ring buffer (peek)");
-    fail_unless(((intptr_t) cork_ring_buffer_pop(&buf)) == 1,
+    ck_assert_msg(((intptr_t) cork_ring_buffer_pop(&buf)) == 1,
                 "Unexpected head of ring buffer (pop)");
-    fail_unless(((intptr_t) cork_ring_buffer_pop(&buf)) == 2,
+    ck_assert_msg(((intptr_t) cork_ring_buffer_pop(&buf)) == 2,
                 "Unexpected head of ring buffer (pop)");
 
-    fail_unless(cork_ring_buffer_add(&buf, (void *) 5) == 0,
+    ck_assert_msg(cork_ring_buffer_add(&buf, (void *) 5) == 0,
                 "Cannot add to ring buffer");
-    fail_unless(cork_ring_buffer_add(&buf, (void *) 6) == 0,
+    ck_assert_msg(cork_ring_buffer_add(&buf, (void *) 6) == 0,
                 "Cannot add to ring buffer");
-    fail_if(cork_ring_buffer_add(&buf, (void *) 7) == 0,
+    ck_assert_false_msg(cork_ring_buffer_add(&buf, (void *) 7) == 0,
             "Shouldn't be able to add to ring buffer");
 
-    fail_unless(((intptr_t) cork_ring_buffer_pop(&buf)) == 3,
+    ck_assert_msg(((intptr_t) cork_ring_buffer_pop(&buf)) == 3,
                 "Unexpected head of ring buffer (pop)");
-    fail_unless(((intptr_t) cork_ring_buffer_pop(&buf)) == 4,
+    ck_assert_msg(((intptr_t) cork_ring_buffer_pop(&buf)) == 4,
                 "Unexpected head of ring buffer (pop)");
-    fail_unless(((intptr_t) cork_ring_buffer_pop(&buf)) == 5,
+    ck_assert_msg(((intptr_t) cork_ring_buffer_pop(&buf)) == 5,
                 "Unexpected head of ring buffer (pop)");
-    fail_unless(((intptr_t) cork_ring_buffer_pop(&buf)) == 6,
+    ck_assert_msg(((intptr_t) cork_ring_buffer_pop(&buf)) == 6,
                 "Unexpected head of ring buffer (pop)");
-    fail_unless(cork_ring_buffer_pop(&buf) == NULL,
+    ck_assert_msg(cork_ring_buffer_pop(&buf) == NULL,
                 "Shouldn't be able to pop from ring buffer");
 
     cork_ring_buffer_done(&buf);
@@ -73,40 +73,40 @@ START_TEST(test_ring_buffer_2)
 {
     struct cork_ring_buffer  *buf = cork_ring_buffer_new(4);
 
-    fail_unless(cork_ring_buffer_add(buf, (void *) 1) == 0,
+    ck_assert_msg(cork_ring_buffer_add(buf, (void *) 1) == 0,
                 "Cannot add to ring buffer");
-    fail_unless(cork_ring_buffer_add(buf, (void *) 2) == 0,
+    ck_assert_msg(cork_ring_buffer_add(buf, (void *) 2) == 0,
                 "Cannot add to ring buffer");
-    fail_unless(cork_ring_buffer_add(buf, (void *) 3) == 0,
+    ck_assert_msg(cork_ring_buffer_add(buf, (void *) 3) == 0,
                 "Cannot add to ring buffer");
-    fail_unless(cork_ring_buffer_add(buf, (void *) 4) == 0,
+    ck_assert_msg(cork_ring_buffer_add(buf, (void *) 4) == 0,
                 "Cannot add to ring buffer");
-    fail_if(cork_ring_buffer_add(buf, (void *) 5) == 0,
+    ck_assert_false_msg(cork_ring_buffer_add(buf, (void *) 5) == 0,
             "Shouldn't be able to add to ring buffer");
 
-    fail_unless(((intptr_t) cork_ring_buffer_peek(buf)) == 1,
+    ck_assert_msg(((intptr_t) cork_ring_buffer_peek(buf)) == 1,
                 "Unexpected head of ring buffer (peek)");
-    fail_unless(((intptr_t) cork_ring_buffer_pop(buf)) == 1,
+    ck_assert_msg(((intptr_t) cork_ring_buffer_pop(buf)) == 1,
                 "Unexpected head of ring buffer (pop)");
-    fail_unless(((intptr_t) cork_ring_buffer_pop(buf)) == 2,
+    ck_assert_msg(((intptr_t) cork_ring_buffer_pop(buf)) == 2,
                 "Unexpected head of ring buffer (pop)");
 
-    fail_unless(cork_ring_buffer_add(buf, (void *) 5) == 0,
+    ck_assert_msg(cork_ring_buffer_add(buf, (void *) 5) == 0,
                 "Cannot add to ring buffer");
-    fail_unless(cork_ring_buffer_add(buf, (void *) 6) == 0,
+    ck_assert_msg(cork_ring_buffer_add(buf, (void *) 6) == 0,
                 "Cannot add to ring buffer");
-    fail_if(cork_ring_buffer_add(buf, (void *) 7) == 0,
+    ck_assert_false_msg(cork_ring_buffer_add(buf, (void *) 7) == 0,
             "Shouldn't be able to add to ring buffer");
 
-    fail_unless(((intptr_t) cork_ring_buffer_pop(buf)) == 3,
+    ck_assert_msg(((intptr_t) cork_ring_buffer_pop(buf)) == 3,
                 "Unexpected head of ring buffer (pop)");
-    fail_unless(((intptr_t) cork_ring_buffer_pop(buf)) == 4,
+    ck_assert_msg(((intptr_t) cork_ring_buffer_pop(buf)) == 4,
                 "Unexpected head of ring buffer (pop)");
-    fail_unless(((intptr_t) cork_ring_buffer_pop(buf)) == 5,
+    ck_assert_msg(((intptr_t) cork_ring_buffer_pop(buf)) == 5,
                 "Unexpected head of ring buffer (pop)");
-    fail_unless(((intptr_t) cork_ring_buffer_pop(buf)) == 6,
+    ck_assert_msg(((intptr_t) cork_ring_buffer_pop(buf)) == 6,
                 "Unexpected head of ring buffer (pop)");
-    fail_unless(cork_ring_buffer_pop(buf) == NULL,
+    ck_assert_msg(cork_ring_buffer_pop(buf) == NULL,
                 "Shouldn't be able to pop from ring buffer");
 
     cork_ring_buffer_free(buf);

--- a/tests/test-slice.c
+++ b/tests/test-slice.c
@@ -35,13 +35,13 @@ START_TEST(test_static_slice)
     cork_slice_init_static(&slice, SRC, SRC_LEN);
     fail_if_error(cork_slice_copy_offset(&advanced, &slice, 0));
     fail_if_error(original = cork_slice_advance(&advanced, 4));
-    fail_unless(strcmp(SRC, original) == 0,
+    ck_assert_msg(strcmp(SRC, original) == 0,
                 "Advance should return original buffer");
     fail_if_error(cork_slice_copy(&copy1, &slice, 8, 4));
     fail_if_error(cork_slice_light_copy(&lcopy1, &slice, 8, 4));
     fail_if_error(cork_slice_slice(&slice, 8, 4));
-    fail_unless(cork_slice_equal(&slice, &copy1), "Slices should be equal");
-    fail_unless(cork_slice_equal(&slice, &lcopy1), "Slices should be equal");
+    ck_assert_msg(cork_slice_equal(&slice, &copy1), "Slices should be equal");
+    ck_assert_msg(cork_slice_equal(&slice, &lcopy1), "Slices should be equal");
     /* We have to finish lcopy1 first, since it's a light copy. */
     cork_slice_finish(&lcopy1);
     cork_slice_finish(&slice);
@@ -67,38 +67,38 @@ START_TEST(test_copy_once_slice)
     struct cork_slice  lcopy2;
 
     cork_slice_init_copy_once(&slice, SRC, SRC_LEN);
-    fail_unless(slice.buf == SRC, "Unexpected slice buffer");
+    ck_assert_msg(slice.buf == SRC, "Unexpected slice buffer");
 
     fail_if_error(cork_slice_light_copy(&lcopy1, &slice, 8, 4));
     /* We should still be using the original SRC buffer directly, since we only
      * created a light copy. */
-    fail_unless(slice.buf == SRC, "Unexpected slice buffer");
-    fail_unless(slice.buf + 8 == lcopy1.buf, "Unexpected slice buffer");
+    ck_assert_msg(slice.buf == SRC, "Unexpected slice buffer");
+    ck_assert_msg(slice.buf + 8 == lcopy1.buf, "Unexpected slice buffer");
 
     fail_if_error(cork_slice_copy(&copy1, &slice, 8, 4));
     fail_if_error(cork_slice_slice(&slice, 8, 4));
     /* Once we create a full copy, the content should have been moved into a
      * managed buffer, which will exist somewhere else in memory than the
      * original SRC pointer. */
-    fail_unless(slice.buf != SRC, "Unexpected slice buffer");
-    fail_unless(slice.buf == copy1.buf, "Unexpected slice buffer");
+    ck_assert_msg(slice.buf != SRC, "Unexpected slice buffer");
+    ck_assert_msg(slice.buf == copy1.buf, "Unexpected slice buffer");
     /* The light copy that we made previously won't have been moved over to the
      * new managed buffer, though. */
-    fail_unless(cork_slice_equal(&slice, &copy1), "Slices should be equal");
+    ck_assert_msg(cork_slice_equal(&slice, &copy1), "Slices should be equal");
 
     /* Once we've switched over to the managed buffer, a new light copy should
      * still point into the managed buffer. */
     fail_if_error(cork_slice_light_copy(&lcopy2, &slice, 0, 4));
-    fail_unless(slice.buf != SRC, "Unexpected slice buffer");
-    fail_unless(slice.buf == lcopy2.buf, "Unexpected slice buffer");
+    ck_assert_msg(slice.buf != SRC, "Unexpected slice buffer");
+    ck_assert_msg(slice.buf == lcopy2.buf, "Unexpected slice buffer");
 
     fail_if_error(cork_slice_copy(&copy2, &slice, 0, 4));
     /* The second full copy should not create a new managed buffer, it should
      * just increment the existing managed buffer's refcount. */
-    fail_unless(slice.buf == copy2.buf, "Unexpected slice buffer");
-    fail_unless(copy1.buf == copy2.buf, "Unexpected slice buffer");
-    fail_unless(cork_slice_equal(&slice, &copy2), "Slices should be equal");
-    fail_unless(cork_slice_equal(&copy1, &copy2), "Slices should be equal");
+    ck_assert_msg(slice.buf == copy2.buf, "Unexpected slice buffer");
+    ck_assert_msg(copy1.buf == copy2.buf, "Unexpected slice buffer");
+    ck_assert_msg(cork_slice_equal(&slice, &copy2), "Slices should be equal");
+    ck_assert_msg(cork_slice_equal(&copy1, &copy2), "Slices should be equal");
 
     /* We have to finish the light copies first. */
     cork_slice_finish(&lcopy1);

--- a/tests/test-subprocess.c
+++ b/tests/test-subprocess.c
@@ -56,7 +56,7 @@ verify_consumer__eof(struct cork_stream_consumer *vself)
     if (actual == NULL) {
         actual = "";
     }
-    fail_unless(strcmp(actual, self->expected) == 0,
+    ck_assert_msg(strcmp(actual, self->expected) == 0,
                 "Unexpected %s: got\n%s\nexpected\n%s\n", self->name,
                 actual, self->expected);
     return 0;

--- a/tests/test-threads.c
+++ b/tests/test-threads.c
@@ -29,13 +29,13 @@
 #define test_atomic_op(name, type, fmt, op, expected) \
     do { \
         type  actual = cork_##name##_atomic_##op(&val, 1); \
-        fail_unless_equal(#name, fmt, expected, actual); \
+        fail_unless_equal(#name, fmt, (type)expected, actual); \
     } while (0)
 
 #define test_cas(name, type, fmt, ov, nv) \
     do { \
         type  actual = cork_##name##_cas(&val, ov, nv); \
-        fail_unless_equal(#name, fmt, ov, actual); \
+        fail_unless_equal(#name, fmt, (type)ov, (type)actual); \
     } while (0)
 
 #define test_atomic(name, type, fmt) \
@@ -47,18 +47,18 @@ START_TEST(test_atomic_##name) \
     test_atomic_op(name, type, fmt, pre_add, 1); \
     test_atomic_op(name, type, fmt, add, 3); \
     test_atomic_op(name, type, fmt, pre_add, 3); \
-    fail_unless_equal(#name, fmt, 4, val); \
+    fail_unless_equal(#name, fmt, (type)4, val); \
     test_atomic_op(name, type, fmt, sub, 3); \
     test_atomic_op(name, type, fmt, pre_sub, 3); \
     test_atomic_op(name, type, fmt, sub, 1); \
     test_atomic_op(name, type, fmt, pre_sub, 1); \
-    fail_unless_equal(#name, fmt, 0, val); \
+    fail_unless_equal(#name, fmt, (type)0, val); \
     \
     test_cas(name, type, fmt, 0, 1); \
     test_cas(name, type, fmt, 1, 10); \
     test_cas(name, type, fmt, 10, 2); \
     test_cas(name, type, fmt, 2, 0); \
-    fail_unless_equal(#name, fmt, 0, val); \
+    fail_unless_equal(#name, fmt, (type)0, val); \
 } \
 END_TEST
 
@@ -112,7 +112,7 @@ START_TEST(test_once)
     cork_once(once, go);
     fail_unless_equal("Value", "%d", 1, value);
 
-    fail_unless_equal("Call count", "%zu", 1, call_count);
+    fail_unless_equal("Call count", "%zu", (size_t)1, call_count);
 }
 END_TEST
 
@@ -139,7 +139,7 @@ START_TEST(test_once_recursive)
     cork_once_recursive(once, go);
     fail_unless_equal("Value", "%d", 1, value);
 
-    fail_unless_equal("Call count", "%zu", 1, call_count);
+    fail_unless_equal("Call count", "%zu", (size_t)1, call_count);
 }
 END_TEST
 
@@ -152,7 +152,7 @@ START_TEST(test_thread_ids)
 {
     DESCRIBE_TEST;
     cork_thread_id  id = cork_current_thread_get_id();
-    fail_if(id == CORK_THREAD_NONE, "Expected a valid thread ID");
+    ck_assert_false_msg(id == CORK_THREAD_NONE, "Expected a valid thread ID");
 }
 END_TEST
 
@@ -277,7 +277,7 @@ START_TEST(test_threads_error_01)
     fail_if_error(t1 = cork_thread_new
                   ("test", NULL, NULL, cork_error_thread__run));
     fail_if_error(cork_thread_start(t1));
-    fail_unless_error(cork_thread_join(t1));
+    fail_unless_error(cork_thread_join(t1), "Cannot join the thread");
 }
 END_TEST
 

--- a/tests/test-u128.c
+++ b/tests/test-u128.c
@@ -173,7 +173,7 @@ check_shift_test(cork_u128(op)(cork_u128, unsigned int), const char *op_str,
         fprintf(stderr, "#  %s %40u\n", op_str, test->j);
         fprintf(stderr, "#   = %40s\n", expected_str);
         fprintf(stderr, "# got %40s\n", result_str);
-        fail("Unexpected shift error");
+        ck_abort_msg("Unexpected shift error");
     }
 }
 
@@ -252,7 +252,7 @@ check_arithmetic_test(cork_u128(op)(cork_u128, cork_u128), const char *op_str,
         fprintf(stderr, "#   %s %40s\n", op_str, value2_str);
         fprintf(stderr, "#   = %40s\n", expected_str);
         fprintf(stderr, "# got %40s\n", result_str);
-        fail("Unexpected arithmetic error");
+        ck_abort_msg("Unexpected arithmetic error");
     }
 }
 
@@ -328,7 +328,7 @@ check_comparison_test(bool(op)(cork_u128, cork_u128), const char *op_str,
         fprintf(stderr, "#  %s %40s\n", op_str, value2_str);
         fprintf(stderr, "#   = %s\n", test->expected? "true": "false");
         fprintf(stderr, "# got %s\n", actual? "true": "false");
-        fail("Unexpected comparison error");
+        ck_abort_msg("Unexpected comparison error");
     }
 }
 


### PR DESCRIPTION
Make the code compile on the recent gcc. The patch does following things:

  - Adopt to the new libcheck api. The old ones like fail, fail_if, fail_unless are deprecated and can't compile on the recent gcc.
  - Other format-string related fixes like unmatched types.