### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,9 @@ find_package(CTargets)
 
 execute_process(
     COMMAND
-      ${CMAKE_SOURCE_DIR}/build-aux/calculate version
-        ${CMAKE_SOURCE_DIR} .version-stamp
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/build-aux/calculate version
+        ${CMAKE_CURRENT_SOURCE_DIR} .version-stamp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     RESULT_VARIABLE VERSION_RESULT
     OUTPUT_VARIABLE VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -46,9 +46,9 @@ set(CORK_VERSION "${VERSION}")
 
 execute_process(
     COMMAND
-      ${CMAKE_SOURCE_DIR}/build-aux/calculate commit
-        ${CMAKE_SOURCE_DIR} .commit-stamp
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/build-aux/calculate commit
+        ${CMAKE_CURRENT_SOURCE_DIR} .commit-stamp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     RESULT_VARIABLE GIT_SHA1_RESULT
     OUTPUT_VARIABLE CORK_GIT_SHA1
     OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
When integrate this library to a project with add_subdirectory, below error will be reported because CMAKE_SOURCE_DIR isn't interpreted as the root directory of libcork. CMAKE_CURRENT_SOURCE_DIR should be a better choice.
```
CMake Error at libcork/CMakeLists.txt:31 (message):
  Cannot determine version number: No such file or directory
```